### PR TITLE
Metafile decorators properly resolve nested file trees in containsDecorator

### DIFF
--- a/__test__/metafiles.spec.ts
+++ b/__test__/metafiles.spec.ts
@@ -57,6 +57,7 @@ describe('metafiles.extractMetafile', () => {
   it('extractMetafile resolves a non-empty directory with Redux actions', async () => {
     const metafilePayload = await extractMetafile('foo/zap', mockedFiletypes, mockedRepositories);
     expect(metafilePayload.actions).toHaveLength(6);
+    expect(metafilePayload.metafile.contains).toHaveLength(2);
   });
 
 

--- a/src/containers/metafiles.ts
+++ b/src/containers/metafiles.ts
@@ -112,7 +112,7 @@ const containsDecorator = async (metafilePayload: MetafilePayload, filetypes: Fi
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   const childPayloads = await Promise.all(childPaths.map(childPath => extractMetafile(childPath, filetypes, repos)));
   const childActions: IdentifiableActions[] = flatten(childPayloads.map(childPayload => childPayload.actions));
-  const childMetafileIds = childActions.map(childAction => childAction.id);
+  const childMetafileIds = childPayloads.map(childPayload => childPayload.metafile.id);
 
   return {
     metafile: { ...metafilePayload.metafile, contains: childMetafileIds },


### PR DESCRIPTION
In order to populate the Redux store with all necessary objects (`Metafile`, `Repository`, etc.), the `containsDecorator` function recursively calls `extractMetafile` on all sub-child directories and collects all of the Redux actions necessary (`ADD_METAFILE`, `UPDATE_METAFILE`, `ADD_REPO`, `UPDATE_REPO`) to bubble up further in the call stack. 

The `childActions` list of all Redux actions is flattened so that the file hierarchy is no longer maintained, since Redux updates (via reducers) are processed in a linear queue format. However, this flattened list of actions was erroneously used to also populate the `contains` field within the `Metafile` object for the current directory. This resulted in directories being listed with the UUIDs of all descendant directories and files, instead of only the direct descendants.

This bugfix change switches to using the `childPayloads` list, which contains a non-flattened list of Redux actions (along with `Metafile` objects) in order to correctly populate the `contains` field with UUIDs of only sub-directories and sub-files. An update to the test suite is included to catch this particular error in the future.