### PR TITLE
Bump eslint-plugin-testing-library from 3.8.0 to 3.9.0, closes #134

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint-plugin-jest-dom": "^3.1.7",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
-    "eslint-plugin-testing-library": "^3.8.0",
+    "eslint-plugin-testing-library": "^3.9.0",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^5.2.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
Resolves #134, which was dependent on a resolution to https://github.com/testing-library/eslint-plugin-testing-library/pull/139, by increasing the minimum version for [`eslint-plugin-testing-library`](https://www.npmjs.com/package/eslint-plugin-testing-library) from `^3.8.0` to `^3.9.0`. This version includes support for [ESLint v7.0.0](https://eslint.org/blog/2020/05/eslint-v7.0.0-released).