### PR TITLE
Remove redundant copy-webpack-plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.12.0",
     "@zeit/webpack-asset-relocator-loader": "^0.8.0",
-    "copy-webpack-plugin": "^7.0.0",
     "css-loader": "^5.0.1",
     "electron": "11.1.1",
     "electron-devtools-installer": "^3.0.0",

--- a/webpack.plugins.js
+++ b/webpack.plugins.js
@@ -1,14 +1,8 @@
 const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = [
   new ForkTsCheckerWebpackPlugin({
     async: false
   }),
-  new CopyWebpackPlugin({
-    patterns: [
-      { from: 'src/assets', to: 'assets' }
-    ]
-  })
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,17 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
+"@typescript-eslint/experimental-utils@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
+  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/typescript-estree" "3.10.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
 "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz#372838e76db76c9a56959217b768a19f7129546b"
@@ -3364,20 +3375,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-webpack-plugin@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-7.0.0.tgz#3506f867ca6e861ee2769d4deaf8fa0d2563ada9"
-  integrity sha512-SLjQNa5iE3BoCP76ESU9qYo9ZkEWtXoZxDurHoqPchAFRblJ9g96xTeC560UXBMre1Nx6ixIIUfiY3VcjpJw3g==
-  dependencies:
-    fast-glob "^3.2.4"
-    glob-parent "^5.1.1"
-    globby "^11.0.1"
-    loader-utils "^2.0.0"
-    normalize-path "^3.0.0"
-    p-limit "^3.0.2"
-    schema-utils "^3.0.0"
-    serialize-javascript "^5.0.1"
-
 core-js-pure@^3.0.0:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.2.tgz#286f885c0dac1cdcd6d78397392abc25ddeca225"
@@ -4867,7 +4864,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1, fast-glob@^3.2.4:
+fast-glob@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
@@ -5407,7 +5404,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==


### PR DESCRIPTION
### **Description**:

Examining `devDependencies` in light of #265, it appears that asset bundling in [Electron](https://www.electronjs.org/) (using [webpack](https://webpack.js.org/)) _"just works"_ as of Electron [v6.0.0-beta.54](https://github.com/electron-userland/electron-forge/releases/tag/v6.0.0-beta.54). It is unclear which specific PR or version (could be all the way back to [v6.0.0-beta.51](https://github.com/electron-userland/electron-forge/releases/tag/v6.0.0-beta.51)) introduces the specific fix that resolves the need for [`copy-webpack-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin).

We can now mark [`copy-webpack-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin) as redundant and remove it from `devDependencies`, which will reduce our development bundle size.

This PR resolves #265, and signifies the following version changes:
* [ ] MAJOR version increase
* [ ] MINOR version increase
* [X] PATCH version increase

### **Changes**:

This PR makes the following changes:
* Remove [`copy-webpack-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin) from `devDependencies`.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
