### PR TITLE
Enable ESLint quotes rule for single quotes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,10 @@ module.exports = {
     es2017: true,
     jest: true
   },
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: "module",
+    sourceType: 'module',
     jsx: true,
     ecmaFeatures: {
       jsx: true
@@ -16,79 +16,80 @@ module.exports = {
     project: './tsconfig.eslint.json'
   },
   plugins: [
-    "@typescript-eslint",
-    "react",
-    "react-hooks",
-    "jest",
-    "jest-dom",
-    "testing-library"
+    '@typescript-eslint',
+    'react',
+    'react-hooks',
+    'jest',
+    'jest-dom',
+    'testing-library'
   ],
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
-    "plugin:import/typescript",
-    "plugin:jest/recommended",
-    "plugin:jest/style",
-    "plugin:jest-dom/recommended",
-    "plugin:react/recommended",
-    "plugin:testing-library/recommended",
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    'plugin:import/typescript',
+    'plugin:jest/recommended',
+    'plugin:jest/style',
+    'plugin:jest-dom/recommended',
+    'plugin:react/recommended',
+    'plugin:testing-library/recommended',
   ],
   settings: {
-    "import/core-modules": ["electron"], // https://github.com/benmosher/eslint-plugin-import/blob/master/README.md#importcore-modules
-    "import/resolver": { // https://github.com/benmosher/eslint-plugin-import#resolvers
+    'import/core-modules': ['electron'], // https://github.com/benmosher/eslint-plugin-import/blob/master/README.md#importcore-modules
+    'import/resolver': { // https://github.com/benmosher/eslint-plugin-import#resolvers
       node: {
-        extensions: [".js", ".jsx", ".ts", ".d.ts", ".tsx"]
+        extensions: ['.js', '.jsx', '.ts', '.d.ts', '.tsx']
       }
     },
-    "import/ignore": [".scss", ".less", ".css"], // eslint-plugin-import can't parse unprocessed CSS modules
-    "import/no-unresolved": {
-      ignore: [".scss$", ".less$", ".css$"] // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md#ignore
+    'import/ignore': ['.scss', '.less', '.css'], // eslint-plugin-import can't parse unprocessed CSS modules
+    'import/no-unresolved': {
+      ignore: ['.scss$', '.less$', '.css$'] // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md#ignore
     },
     react: {
-      pragma: "React",
-      version: "detect"
+      pragma: 'React',
+      version: 'detect'
     }
   },
   rules: {
     /**
      * @description Rules of eslint
      */
-    "max-len": ["warn", {
-      "code": 140,
-      "tabWidth": 2,
-      "comments": 140,
-      "ignoreTrailingComments": true,
-      "ignorePattern": "^ \\* \\|.*\\|" // disable checks for Markdown tables, since cell rows cannot span multiple lines
+    'quotes': ['error', 'single', { 'avoidEscape': true }],
+    'max-len': ['warn', {
+      'code': 140,
+      'tabWidth': 2,
+      'comments': 140,
+      'ignoreTrailingComments': true,
+      'ignorePattern': '^ \\* \\|.*\\|' // disable checks for Markdown tables, since cell rows cannot span multiple lines
     }],
-    "no-unused-vars": "off",
+    'no-unused-vars': 'off',
 
     /**
      * @description Rules of typescript-eslint
      */
-    "@typescript-eslint/no-unused-vars": 0,
-    "@typescript-eslint/explicit-function-return-type": "off",
+    '@typescript-eslint/no-unused-vars': 0,
+    '@typescript-eslint/explicit-function-return-type': 'off',
 
     /**
      * @description Rules of eslint-plugin-react
      */
-    "react/prop-types": [0], // disabled checks for PropTypes blocks: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
-    "react/jsx-filename-extension": ["warn", {
-      "extensions": [".jsx", ".tsx"]
+    'react/prop-types': [0], // disabled checks for PropTypes blocks: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
+    'react/jsx-filename-extension': ['warn', {
+      'extensions': ['.jsx', '.tsx']
     }],
 
     /**
      * @description Rules of eslint-plugin-react-hooks
      */
-    "react-hooks/rules-of-hooks": "error", // enforces adherence to the Rules of Hooks: https://reactjs.org/docs/hooks-rules.html
-    "react-hooks/exhaustive-deps": "warn", // described in this thread: https://github.com/facebook/react/issues/14920
+    'react-hooks/rules-of-hooks': 'error', // enforces adherence to the Rules of Hooks: https://reactjs.org/docs/hooks-rules.html
+    'react-hooks/exhaustive-deps': 'warn', // described in this thread: https://github.com/facebook/react/issues/14920
 
     /**
      * @description Rules of eslint-plugin-jest
      */
-    "jest/no-disabled-tests": "warn",
-    "jest/no-mocks-import": "off"
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-mocks-import': 'off'
   }
 }


### PR DESCRIPTION
### **Description**:

Consistent code is readable code, therefore we use [ESLint](https://eslint.or) to validate and fix syntax and formatting inconsistencies. We are adding the following ESLint rule to our configuration:
```javascript
'quotes': ['error', 'single', { 'avoidEscape': true }]
```
Per the ESLint `quotes` documentation (see [here](https://eslint.org/docs/rules/quotes)), the `avoidEscape` option _"allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise."_

This PR resolves #*[XXXX]*, and signifies the following version changes:
* [ ] MAJOR version increase
* [X] MINOR version increase
* [ ] PATCH version increase

### **Changes**:

This PR makes the following changes:
* Adds `quotes` to ESLint for verifying single-quote formatting.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [ ] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
