### PR TITLE
NewCardDialog accepts Enter key press on filename field

### DIFF
--- a/src/components/NewCardDialog.tsx
+++ b/src/components/NewCardDialog.tsx
@@ -26,16 +26,21 @@ export const NewCardDialog: React.FunctionComponent<NewCardDialogProps> = props 
   const [fileName, setFileName] = React.useState('');
   const [filetype, setFiletype] = React.useState('');
   const [isFileNameValid, setIsFileNameValid] = React.useState(false);
-
   const [isExtensionValid, setIsExtensionValid] = React.useState(false);
 
-  const handleClose = () => {
+  const reset = () => {
     setFileName('');
     setFiletype('');
     setIsExtensionValid(false);
     setIsFileNameValid(false);
-    props.onClose();
-  };
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleClick();
+    }
+  }
 
   const handleFileNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFileName(event.target.value);
@@ -77,19 +82,24 @@ export const NewCardDialog: React.FunctionComponent<NewCardDialogProps> = props 
   const handleClick = async () => {
     if (isFileNameValid && filetype !== '' && fileName.indexOf('.') !== -1 && isExtensionValid) {
       const metafile = await dispatch(getMetafile({ virtual: { name: fileName, handler: 'Editor', path: fileName, filetype: filetype } }));
-      if (metafile) dispatch(loadCard({ metafile: metafile }));
-      handleClose();
+      if (metafile) await dispatch(loadCard({ metafile: metafile }));
+      reset();
+      props.onClose();
     }
   };
 
   return (
     <>
-      <Dialog id="new-card-dialog" open={props.open} onClose={handleClose} aria-labelledby="new-card-dialog">
+      <Dialog id="new-card-dialog" open={props.open} onClose={() => props.onClose()} aria-labelledby="new-card-dialog">
         <div className="new-card-dialog-container">
           <DialogTitle id='new-card-dialog-title' style={{ gridArea: 'header' }}>{'Create New Card'}</DialogTitle>
           <InputLabel id="select-file-name-label" style={{ gridArea: 'upper-left' }}>Enter File Name:</InputLabel>
-          <TextField error={isFileNameValid ? false : true} id="new-card-dialog-file-name"
-            helperText={isFileNameValid ? '' : 'Invalid File Name'} value={fileName} onChange={handleFileNameChange}
+          <TextField error={isFileNameValid ? false : true}
+            id="new-card-dialog-file-name"
+            helperText={isFileNameValid ? '' : 'Invalid File Name'}
+            value={fileName}
+            onChange={handleFileNameChange}
+            onKeyDown={(e) => handleKeyDown(e)}
             style={{ gridArea: 'middle' }} />
           <InputLabel id="select-filetype-label" style={{ gridArea: 'lower-left' }}>Select Filetype:</InputLabel>
           <Select error={filetype === '' ? true : false} value={filetype} onChange={handleFiletypeChange}
@@ -98,7 +108,8 @@ export const NewCardDialog: React.FunctionComponent<NewCardDialogProps> = props 
           </Select>
           <Button id='create-card-button' variant='contained'
             color={isFileNameValid && isExtensionValid && filetype !== '' && fileName.indexOf('.') !== -1 ? 'primary' : 'default'}
-            onClick={() => handleClick()} style={{ gridArea: 'subfooter' }}>Create New Card</Button>
+            onClick={() => handleClick()}
+            style={{ gridArea: 'subfooter' }}>Create New Card</Button>
         </div>
       </Dialog>
     </>
@@ -117,7 +128,7 @@ const NewCardButton: React.FunctionComponent = () => {
 
   return (
     <>
-      <Button id='newcard-button' variant='contained' color='primary' onClick={(e) => { handleClick(e) }}>New...</Button>
+      <Button id='newcard-button' variant='contained' color='primary' onClick={(e) => handleClick(e)}>New...</Button>
       <NewCardDialog open={open} onClose={handleClose} />
     </>
   );


### PR DESCRIPTION
### **Description**:

After becoming familiar with the Synectic UI, users will strive to be efficient in their normal usage patterns. When working with forms (e.g. the `NewCardDialog`), the need to first enter information into text fields and then to click on the `Create New Card` button requires switching from keyboard to mouse interactions. Being able to use the `Enter` key press event to signal that a new card should be created is a helpful shortcut.

This PR signifies the following version changes:
* [ ] MAJOR version increase
* [X] MINOR version increase
* [ ] PATCH version increase

### **Changes**:

This PR makes the following changes:
* Adds a `onKeyDown` event handler for the filename field in the `NewCardDialog` component.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
