### PR TITLE
Revert "Bump electron from 11.1.1 to 11.2.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@typescript-eslint/parser": "^4.13.0",
     "@zeit/webpack-asset-relocator-loader": "^0.8.0",
     "css-loader": "^5.0.1",
-    "electron": "11.2.1",
+    "electron": "11.1.1",
     "electron-devtools-installer": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,10 +4249,10 @@ electron-winstaller@^4.0.1:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@11.2.1:
-  version "11.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.2.1.tgz#8641dd1a62911a1144e0c73c34fd9f37ccc65c2b"
-  integrity sha512-Im1y29Bnil+Nzs+FCTq01J1OtLbs+2ZGLLllaqX/9n5GgpdtDmZhS/++JHBsYZ+4+0n7asO+JKQgJD+CqPClzg==
+electron@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.1.tgz#188f036f8282798398dca9513e9bb3b10213e3aa"
+  integrity sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
Reverts EPICLab/synectic#298

Electron 11.2.0 introduces a specific bug (https://github.com/electron/electron/issues/27303) that causes apps to crash when an icon is set on the [`BrowserWindow`](https://www.electronjs.org/docs/api/browser-window) (which is the main construct in Electron for creating, controlling, and loading the app content). This bug appears to effect MacOS and Linux platforms (and Windows is also suspected). We can observe that Synectic does not load in the presence of this update, so we need to wait until the next 11.x.y release (`electron: ^11.2.2`) which will include the fix from https://github.com/electron/electron/pull/27478.