### PR TITLE
Removing cards from Stack when 2 or fewer cards triggers Stack removal

### DIFF
--- a/__test__/stacks.spec.ts
+++ b/__test__/stacks.spec.ts
@@ -1,62 +1,145 @@
+import mock from 'mock-fs';
+import { v4 } from 'uuid';
 import { DateTime } from 'luxon';
 
 import type { Card, Stack } from '../src/types';
 import * as stacks from '../src/containers/stacks';
+import { mockStore } from './__mocks__/reduxStoreMock';
 import { ActionKeys } from '../src/store/actions';
 import { removeItemInArray } from '../src/store/immutables';
 
-const cards: Card[] = [
+const sampleCards: Card[] = [
   {
-    id: 't829w0351',
+    id: 'u83vx940k',
+    name: 'card0',
+    type: 'Editor',
+    metafile: '48500141',
+    captured: undefined,
+    created: DateTime.fromISO('2016-01-01T01:05:40.001-08:00'),
+    modified: DateTime.fromISO('2016-01-01T01:05:43.153-08:00'),
+    left: 395, top: 403
+  },
+  {
+    id: '0tz6nuq30',
     name: 'card1',
     type: 'Editor',
+    metafile: '62882471',
+    captured: undefined,
+    created: DateTime.fromISO('2013-01-01T01:05:40.001-08:00'),
+    modified: DateTime.fromISO('2014-01-01T01:05:43.153-08:00'),
+    left: 114, top: 27
+  },
+  {
+    id: 't829w0351',
+    name: 'card2',
+    type: 'Editor',
     metafile: '84354571',
+    captured: 'h20z915v7',
     created: DateTime.fromISO('2014-04-09T08:14:02.371-08:00'),
     modified: DateTime.fromISO('2014-06-23T21:58:44.507-08:00'),
-    left: 100, top: 50
+    left: 10, top: 50
   },
   {
     id: '28s3q0ag1',
-    name: 'card2',
+    name: 'card3',
     type: 'Editor',
     metafile: '59237193',
+    captured: 'h20z915v7',
     created: DateTime.fromISO('2014-04-10T08:14:02.371-08:00'),
     modified: DateTime.fromISO('2014-06-23T21:58:46.118-08:00'),
-    left: 120, top: 70
+    left: 20, top: 60
   },
   {
     id: '844et25bk',
-    name: 'card3',
+    name: 'card4',
     type: 'Editor',
     metafile: '85531762',
+    captured: 'h20z915v7',
     created: DateTime.fromISO('2018-09-15T15:54:11.371-08:00'),
     modified: DateTime.fromISO('2019-01-01T09:29:47.061-08:00'),
-    left: 140, top: 90
+    left: 30, top: 70
   },
   {
     id: '6aa5409b3',
-    name: 'card4',
+    name: 'card5',
     type: 'Browser',
     metafile: '58598471',
+    captured: 'h20z915v7',
     created: DateTime.fromISO('2011-01-01T01:05:40.001-08:00'),
     modified: DateTime.fromISO('2011-01-01T01:05:43.153-08:00'),
-    left: 131, top: 19
+    left: 10, top: 50
+  },
+  {
+    id: 'b99rt1f05',
+    name: 'card6',
+    type: 'Editor',
+    metafile: '88672031',
+    captured: 'h20z915v7',
+    created: DateTime.fromISO('2019-01-01T01:05:40.001-08:00'),
+    modified: DateTime.fromISO('2010-01-01T01:05:43.153-08:00'),
+    left: 20, top: 60
   }];
 
-const stack: Stack = {
+const sampleStacks: Stack[] = [{
   id: 'h20z915v7',
   name: 'testStack',
   created: DateTime.fromISO('2014-04-09T08:14:02.371-08:00'),
   modified: DateTime.fromISO('2014-06-23T21:58:44.507-08:00'),
-  note: 'example note text',
-  cards: [cards[0].id, cards[1].id],
+  note: 'sample stack with >2 cards',
+  cards: ['t829w0351', '28s3q0ag1', '844et25bk'],
   left: 100,
   top: 50
-};
+},
+{
+  id: 'h20z915v7',
+  name: 'testStack',
+  created: DateTime.fromISO('2012-04-09T08:14:02.371-08:00'),
+  modified: DateTime.fromISO('2012-06-23T21:58:44.507-08:00'),
+  note: 'sample stack with 2 cards',
+  cards: ['6aa5409b3', 'b99rt1f05'],
+  left: 250,
+  top: 120
+}];
+
+const cardsMap = sampleCards.reduce((innerMap: { [id: string]: Card; }, card) => {
+  innerMap[card.id] = card;
+  return innerMap;
+}, {});
+
+const stacksMap = sampleStacks.reduce((innerMap: { [id: string]: Stack; }, stack) => {
+  innerMap[stack.id] = stack;
+  return innerMap;
+}, {});
+
+const store = mockStore({
+  canvas: {
+    id: v4(),
+    created: DateTime.fromISO('1991-12-26T08:00:00.000-08:00'),
+    repos: [],
+    cards: [...sampleCards.map(c => c.id)],
+    stacks: [...sampleStacks.map(s => s.id)]
+  },
+  stacks: {
+    ...stacksMap
+  },
+  cards: {
+    ...cardsMap
+  },
+  filetypes: {},
+  metafiles: {},
+  repos: {},
+  errors: {}
+});
+
+afterEach(() => {
+  store.clearActions();
+  jest.clearAllMocks();
+});
+afterAll(mock.restore);
 
 describe('stacks.addStack', () => {
   it('addStack resolves ADD_STACK and UPDATE_CARD actions for each child Card', () => {
-    const actions = stacks.addStack('testStack', [cards[0], cards[1]]);
+    const actions = stacks.addStack('testStack', [sampleCards[0], sampleCards[1]]);
     expect(actions).toHaveLength(3);
     expect(actions).toEqual(
       expect.arrayContaining([
@@ -69,27 +152,28 @@ describe('stacks.addStack', () => {
 
 describe('stacks.updateStack', () => {
   it('updateStack resolves UPDATE_STACK action for adding child Card', () => {
-    const action = stacks.updateStack({ ...stack, cards: [...stack.cards, cards[2].id] });
-    expect(action.stack.cards).toHaveLength(3);
+    const targetStack = sampleStacks[0];
+    const action = stacks.updateStack({ ...targetStack, cards: [...targetStack.cards, sampleCards[0].id] });
+    expect(action.stack.cards).toHaveLength(4);
     expect(action).toEqual(
       expect.objectContaining({
         type: ActionKeys.UPDATE_STACK,
         stack: expect.objectContaining({
-          cards: expect.arrayContaining([cards[0].id, cards[1].id, cards[2].id])
+          cards: expect.arrayContaining([sampleCards[0].id, sampleCards[2].id, sampleCards[3].id, sampleCards[4].id])
         })
       })
     );
   });
 
   it('updateStack resolves UPDATE_STACK action for removing child Card', () => {
-    const updatedCards = removeItemInArray(stack.cards, cards[1].id);
-    const action = stacks.updateStack({ ...stack, cards: updatedCards });
-    expect(action.stack.cards).toHaveLength(1);
+    const updatedCards = removeItemInArray(sampleStacks[0].cards, sampleCards[2].id);
+    const action = stacks.updateStack({ ...sampleStacks[0], cards: updatedCards });
+    expect(action.stack.cards).toHaveLength(2);
     expect(action).toEqual(
       expect.objectContaining({
         type: ActionKeys.UPDATE_STACK,
         stack: expect.objectContaining({
-          cards: expect.arrayContaining([cards[0].id])
+          cards: expect.arrayContaining([sampleCards[3].id, sampleCards[4].id])
         })
       })
     );
@@ -98,32 +182,33 @@ describe('stacks.updateStack', () => {
 
 describe('stacks.appendCard', () => {
   it('appendCard resolves UPDATE_STACK and UPDATE_CARD actions for adding child Cards', () => {
-    const actions = stacks.appendCards(stack, [cards[2], cards[3]]);
+    const targetStack = sampleStacks[0];
+    const actions = stacks.appendCards(targetStack, [sampleCards[0], sampleCards[1]]);
     expect(actions).toHaveLength(3);
     expect(actions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: ActionKeys.UPDATE_STACK,
           stack: expect.objectContaining({
-            cards: expect.arrayContaining([cards[2].id, cards[3].id])
+            cards: expect.arrayContaining([sampleCards[0].id, sampleCards[1].id])
           })
         }),
         expect.objectContaining({
           type: ActionKeys.UPDATE_CARD,
           card: expect.objectContaining({
-            id: cards[2].id,
-            captured: stack.id,
-            top: (10 * (stack.cards.length + 0) + 50),
-            left: (10 * (stack.cards.length + 0) + 10)
+            id: sampleCards[0].id,
+            captured: sampleStacks[0].id,
+            left: (10 * (targetStack.cards.length + 0) + 10),
+            top: (10 * (targetStack.cards.length + 0) + 50)
           })
         }),
         expect.objectContaining({
           type: ActionKeys.UPDATE_CARD,
           card: expect.objectContaining({
-            id: cards[3].id,
-            captured: stack.id,
-            top: (10 * (stack.cards.length + 1) + 50),
-            left: (10 * (stack.cards.length + 1) + 10)
+            id: sampleCards[1].id,
+            captured: targetStack.id,
+            left: (10 * (targetStack.cards.length + 1) + 10),
+            top: (10 * (targetStack.cards.length + 1) + 50)
           })
         })
       ])
@@ -132,23 +217,55 @@ describe('stacks.appendCard', () => {
 });
 
 describe('stacks.removeCard', () => {
-  it('removeCard resolves UPDATE_STACK and UPDATE_CARD actions for removing child Card', () => {
-    const actions = stacks.removeCard(stack, cards[1], { x: 10, y: 50 });
-    expect(actions).toHaveLength(2);
-    expect(actions).toEqual(
+  it('removeCard resolves UPDATE_STACK and UPDATE_CARD actions for removing from Stack with >2 cards', () => {
+    const targetStack = sampleStacks[0];
+    store.dispatch(stacks.removeCard(targetStack, sampleCards[2], { x: 32, y: 14 }));
+    expect(store.getActions()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: ActionKeys.UPDATE_STACK,
           stack: expect.objectContaining({
-            cards: expect.not.arrayContaining([cards[1].id])
+            cards: expect.not.arrayContaining([sampleCards[2].id])
           })
         }),
         expect.objectContaining({
           type: ActionKeys.UPDATE_CARD,
           card: expect.objectContaining({
+            id: sampleCards[2].id,
             captured: undefined,
-            top: stack.top + cards[1].top + 50,
-            left: stack.left + cards[1].left + 10
+            left: targetStack.left + sampleCards[2].left + 32,
+            top: targetStack.top + sampleCards[2].top + 14
+          })
+        })
+      ])
+    );
+  });
+
+  it('removeCard resolves REMOVE_STACK and UPDATE_CARD actions for removing from Stack with 2 cards', () => {
+    const targetStack = sampleStacks[1];
+    store.dispatch(stacks.removeCard(targetStack, sampleCards[5], { x: 32, y: 14 }));
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: ActionKeys.REMOVE_STACK,
+          id: targetStack.id
+        }),
+        expect.objectContaining({
+          type: ActionKeys.UPDATE_CARD,
+          card: expect.objectContaining({
+            id: sampleCards[5].id,
+            captured: undefined,
+            left: targetStack.left + sampleCards[5].left + 32,
+            top: targetStack.top + sampleCards[5].top + 14
+          })
+        }),
+        expect.objectContaining({
+          type: ActionKeys.UPDATE_CARD,
+          card: expect.objectContaining({
+            id: sampleCards[6].id,
+            captured: undefined,
+            left: targetStack.left + sampleCards[6].left,
+            top: targetStack.top + sampleCards[6].top
           })
         })
       ])

--- a/src/components/CanvasComponent.tsx
+++ b/src/components/CanvasComponent.tsx
@@ -41,8 +41,7 @@ const CanvasComponent: React.FunctionComponent<Canvas> = props => {
           const delta = monitor.getDifferenceFromInitialOffset();
           if (!delta) return; // no dragging is occurring, perhaps a card was picked up and dropped without dragging
           if (card.captured) {
-            const actions = removeCard(stacks[card.captured], card, delta);
-            actions.map(action => dispatch(action));
+            dispatch(removeCard(stacks[card.captured], card, delta));
           } else {
             dispatch(updateCard({ ...card, left: Math.round(card.left + delta.x), top: Math.round(card.top + delta.y) }));
           }

--- a/src/components/CardComponent.tsx
+++ b/src/components/CardComponent.tsx
@@ -96,8 +96,7 @@ const CardComponent: React.FunctionComponent<Card> = props => {
         case 'CARD': {
           const dropSource = cards[monitor.getItem().id];
           if (dropSource.captured) {
-            const actions = removeCard(stacks[dropSource.captured], dropSource, delta);
-            actions.map(action => dispatch(action));
+            dispatch(removeCard(stacks[dropSource.captured], dropSource, delta));
           }
           if (dropTarget.captured) {
             const actions = appendCards(stacks[dropTarget.captured], [dropSource]);

--- a/src/components/StackComponent.tsx
+++ b/src/components/StackComponent.tsx
@@ -13,6 +13,7 @@ const StackComponent: React.FunctionComponent<Stack> = props => {
   const stacks = useSelector((state: RootState) => state.stacks);
   const dispatch = useDispatch();
 
+  // Enable StackComponent as a drop source (i.e. allowing this stack to be draggable)
   const [{ isDragging }, drag] = useDrag({
     item: { type: 'STACK', id: props.id },
     collect: monitor => ({
@@ -21,6 +22,7 @@ const StackComponent: React.FunctionComponent<Stack> = props => {
     })
   });
 
+  // Enable StackComponent as a drop target (i.e. allow other elements to be dropped on this stack)
   const [, drop] = useDrop({
     accept: ['CARD', 'STACK'],
     canDrop: (item, monitor) => {
@@ -36,8 +38,7 @@ const StackComponent: React.FunctionComponent<Stack> = props => {
           const dropTarget = stacks[props.id];
           const dropSource = cards[monitor.getItem().id];
           if (dropSource.captured) {
-            const actions = removeCard(dropTarget, dropSource, delta);
-            actions.map(action => dispatch(action));
+            dispatch(removeCard(dropTarget, dropSource, delta));
           }
           break;
         }
@@ -49,7 +50,6 @@ const StackComponent: React.FunctionComponent<Stack> = props => {
           actions.map(action => dispatch(action));
           break;
         }
-
       }
     }
   });


### PR DESCRIPTION
### **Description**:

Stacks with fewer than 2 cards contained within them are no longer stacks (by definition they are not a collection of cards). Therefore, when removing a card would lead to a stack no longer containing at least 2 cards then the stack should also be removed from the canvas.

This PR resolves #317, and signifies the following version changes:
* [ ] MAJOR version increase
* [X] MINOR version increase
* [X] PATCH version increase

### **Changes**:

This PR makes the following changes:
* `stacks.removeCard` triggers a `REMOVE_STACK` Redux action if the the target Stack's card count drops below 2.
* `stacks.removeCard` returns a Redux Thunk in order to consume Redux state for card count checking.
* `stacks` test suite updated to evaluate when removing a card results in a stack with less than 2 cards.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
