### PR TITLE
getRepository checks for name-matching repos when url is empty

### DIFF
--- a/src/containers/repos.ts
+++ b/src/containers/repos.ts
@@ -179,9 +179,10 @@ export const getRepository = (filepath: PathLike): ThunkAction<Promise<Repositor
       await isogit.getConfigAll({ fs: fs, dir: root.toString(), path: 'remote.origin.url' }) : undefined;
     const { url, oauth } = (remoteOriginUrls && remoteOriginUrls?.length > 0) ?
       extractFromURL(remoteOriginUrls[0]) : { url: undefined, oauth: undefined };
-    const existing = url ?
-      Object.values(getState().repos).find(r => r.name === extractRepoName(url.href) && r.url.href === url.href)
-      : undefined;
+    // const existo = url ? true : false;
+    const name = url ? extractRepoName(url.href) : extractFilename(root);
+    const existing = url ? Object.values(getState().repos).find(r => r.name === name && r.url.href === url.href)
+      : Object.values(getState().repos).find(r => r.name === name);
     if (existing) {
       // the associated repository is already available in the Redux store
       await dispatch(updateBranches(existing.id));


### PR DESCRIPTION
### **Description**:

[`repos.getRepository`](https://github.com/EPICLab/synectic/blob/development/src/containers/repos.ts#L173-L200) checks for existing repositories within the Redux store by comparing the repo names (in the case of the candidate filepath, the repo name is extracted from the `url.href` value). However, this check only occurs when `url` is set and returns `undefined` otherwise. For filepaths not under version control (i.e. no git repository contains the file), this check properly bypasses any `Repository` object creation/updating. But on a filepath that is under version control with a local-only repository, this check breaks down.

This PR resolves #319, and signifies the following version changes:
* [ ] MAJOR version increase
* [ ] MINOR version increase
* [X] PATCH version increase

### **Changes**:

This PR makes the following changes:
* [`repos.getRepository`](https://github.com/EPICLab/synectic/blob/development/src/containers/repos.ts#L173-L200) checks for existing `Repository` objects in the Redux store by comparing repo `name` only for local-only repositories, and both `name` and `url.href` otherwise.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
