### PR TITLE
useDirectory mock must return fetch with () => Promise<void> type

### DIFF
--- a/__test__/Explorer.spec.tsx
+++ b/__test__/Explorer.spec.tsx
@@ -78,7 +78,7 @@ describe('DirectoryComponent', () => {
       root: root,
       directories: [],
       files: ['foo/bar.js'],
-      fetch: () => { return new Promise((resolve) => resolve()) }
+      fetch: async () => { await new Promise(resolve => resolve(0)) }
     });
     const DirectoryContext = wrapInReduxContext(DirectoryComponent, store);
     render(<TreeView><DirectoryContext root={'foo'} /></TreeView>);


### PR DESCRIPTION
### **Description**:

Jest provided the following warning during full test suite execution:
> A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.

By using the `--detectOpenHandles` option, the following leak was discovered:

```javascript
(node:10491) UnhandledPromiseRejectionWarning: Error: Caught error after test environment was torn down

expect(jest.fn()).toHaveBeenCalledTimes(expected)

Expected number of calls: 1
Received number of calls: 0
(Use `node --trace-warnings ...` to show where the warning was created)
(node:10491) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:10491) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This PR signifies the following version changes:
* [ ] MAJOR version increase
* [ ] MINOR version increase
* [X] PATCH version increase

### **Changes**:

This PR makes the following changes:
* Updates `useDirectory` mock in `DirectoryComponent` test to return `fetch` with the correct `() => Promise<void>` type signature. 

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).

Additionally, I have verified that:
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
