### PR TITLE
Revert "Bump node-loader from 1.0.2 to 2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-serializer-path": "^0.1.15",
     "mock-fs": "^4.13.0",
-    "node-loader": "^2.0.0",
+    "node-loader": "^1.0.2",
     "react-dnd-test-backend": "^14.0.0",
     "react-dnd-test-utils": "^14.0.0",
     "react-test-renderer": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7876,12 +7876,13 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-loader/-/node-loader-2.0.0.tgz#9109a6d828703fd3e0aa03c1baec12a798071562"
-  integrity sha512-I5VN34NO4/5UYJaUBtkrODPWxbobrE4hgDqPrjB25yPkonFhCmZ146vTH+Zg417E9Iwoh1l/MbRs1apc5J295Q==
+node-loader@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/node-loader/-/node-loader-1.0.2.tgz#f8a8f117844652642df1f2abb13ca46242643800"
+  integrity sha512-myxAxpyMR7knjA4Uzwf3gjxaMtxSWj2vpm9o6AYWWxQ1S3XMBNeG2vzYcp/5eW03cBGfgSxyP+wntP8qhBJNhQ==
   dependencies:
     loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Reverts EPICLab/synectic#423

When running Synectic with `node-loader v2.0.0` the following error appears during run-time:
```typescript
Module build failed (from ./node_modules/node-loader/dist/cjs.js):
  TypeError: this.getOptions is not a function
```