### PR TITLE
Revert "Bump electron from 11.4.3 to 13.1.6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@typescript-eslint/parser": "^4.28.1",
     "@vercel/webpack-asset-relocator-loader": "^1.5.0",
     "css-loader": "^5.2.6",
-    "electron": "^13.1.6",
+    "electron": "^11.3.0",
     "electron-devtools-installer": "^3.2.0",
     "eslint": "^7.29.0",
     "eslint-plugin-import": "^2.23.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3818,13 +3818,13 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@^13.1.6:
-  version "13.1.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.6.tgz#6ecaf969255d62ce82cc0b5c948bf26e7dfb489b"
-  integrity sha512-XiB55/JTaQpDFQrD9pulYnOGwaWeMyRIub5ispvoE2bWBvM5zVMLptwMLb0m3KTMrfSkzhedZvOu7fwYvR7L7Q==
+electron@^11.3.0:
+  version "11.4.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.10.tgz#7bcbca82810b82c2f2765824c5e11e3061272ea4"
+  integrity sha512-aQTRgRdHwCW68gxz9qvGCfOUvR4NBbdecLB/mEWX8fMncDFvPMmm+dq2D6zSWWVEKywmsj3+wMMVn3UV2Cl2CQ==
   dependencies:
     "@electron/get" "^1.0.1"
-    "@types/node" "^14.6.2"
+    "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
 emittery@^0.8.1:


### PR DESCRIPTION
Reverts EPICLab/synectic#465

Executing Synectic under this environment results in the following error appearing in the console within the Electron window:
```javascript
__dirname is not defined
```
Needs additional resolution steps to integrate Electron 12 changes (per #401) as well.