### PR TITLE
Live staging/unstaging updates on Git Graph

### DIFF
--- a/src/store/selectors/metafiles.ts
+++ b/src/store/selectors/metafiles.ts
@@ -1,4 +1,4 @@
-import { createDraftSafeSelector, EntityId } from '@reduxjs/toolkit';
+import { createDraftSafeSelector, createSelector, EntityId } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { relative } from 'path';
 import type { Card, FilesystemStatus, Metafile, UUID } from '../../types';
@@ -72,6 +72,14 @@ const selectStagedByRepo = createDraftSafeSelector(
         .filter(m => m.repo === repo && m.status && ['added', 'modified', 'deleted'].includes(m.status))
 )
 
+const selectStagedFieldsByRepo = createSelector(
+    selectors.selectAll,
+    (_state: RootState, repoId: UUID) => repoId,
+    (metafiles, repo) => metafiles.filter(isFileMetafile)
+        .filter(m => m.repo === repo && m.status && ['added', 'modified', 'deleted'].includes(m.status))
+        .map(m => { return { id: m.id, repo: m.repo, branch: m.branch, status: m.status } })
+)
+
 const selectStagedByBranch = createDraftSafeSelector(
     selectors.selectAll,
     (_state: RootState, branchId: UUID) => branchId,
@@ -95,7 +103,7 @@ const selectUnstagedByBranch = createDraftSafeSelector(
 
 const metafileSelectors = {
     ...selectors, selectByIds, selectByFilepath, selectByRepo, selectByBranch, selectByRoot,
-    selectByVirtual, selectByState, selectByCards, selectByConflicted, selectStagedByRepo,
+    selectByVirtual, selectByState, selectByCards, selectByConflicted, selectStagedByRepo, selectStagedFieldsByRepo,
     selectStagedByBranch, selectUnstagedByRepo, selectUnstagedByBranch
 };
 


### PR DESCRIPTION
### **Description**:

The [`GitGraph`](https://github.com/EPICLab/synectic/blob/6e98688c18352899f11d4227a5753374ba78c01f/src/components/GitGraph/GitGraph.tsx) component sets the graph state on initial loading, but does not rerender when changes to the underlying repository are made (e.g. such as staging or committing). For example, editing and staging a file is not reflected on the graph unless the selected repository in [`GitGraphSelect`](https://github.com/EPICLab/synectic/blob/6e98688c18352899f11d4227a5753374ba78c01f/src/components/GitGraph/GitGraphSelect.tsx) is changed (i.e. manually initiated updates). This PR adds git status changes as a trigger for evaluating whether to update the selected Git Graph with new commits, new branches, or staged/unstaged files associated with branches in the repository.

This PR resolves #638, and signifies the following version changes (per [Semantic Version](https://semver.org/)):
* **MINOR** version increase

### **Changes**:

This PR makes the following changes:
* Fix bug where fetching local branches on linked worktrees returned the root of the main worktree instead. (1fca6e96a786bc171aea21350471aaa6f04e549f)
* `git-porcelain.hasStatus()` added for checking for specific git statuses in files and directories. (65972220d3cbb03c049d9d9407bd08f093870f70)
* `selectStagedFieldsByRepo` selector added for obtaining partial `Metafile` fields related to VCS status. (3b9a0b3bc7ddf8292c61ab5ab01fb0a06762e10e)
* Git Graph automatically updates for staging/unstaging of files tracked under selected repository. (34ed058aaa47266c4cae1e77bd5802a0ffa4469e)

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.

