### PR TITLE
Display Synectic version from Help menu

### DIFF
--- a/src/components/CanvasComponent.tsx
+++ b/src/components/CanvasComponent.tsx
@@ -163,6 +163,12 @@ const CanvasComponent: React.FunctionComponent = props => {
     { label: 'Repository...', click: async () => { shell.openExternal('https://github.com/EPICLab/synectic/'); } },
     { label: 'Release Notes...', click: async () => { shell.openExternal('https://github.com/EPICLab/synectic/releases'); } },
     { label: 'View License...', click: async () => { shell.openExternal('https://github.com/EPICLab/synectic/blob/5ec51f6dc9dc857cae58c5253c3334c8f33a63c4/LICENSE'); } },
+    {
+      label: 'Version', click: () => dispatch(modalAdded({
+        id: v4(), type: 'Notification',
+        options: { 'message': `Synectic v${process.env.npm_package_version}` }
+      }))
+    }
   ];
 
   return (


### PR DESCRIPTION
### **Description**:

When submitting a bug report/feature request issue for Synectic, we ask for the version of Synectic being run. However, there is no clear way to discern this information when running one of the release builds. This PR adds functionality to obtain this information during runtime.

This PR signifies the following version changes (per [Semantic Version](https://semver.org/)):
* **MINOR** version increase

### **Changes**:

This PR makes the following changes:
* Adds a `Version` option in the `Help` menu to display a notification with the Synectic version being run.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.

