### PR TITLE
Feat: Dialog for creating new branches

### DIFF
--- a/src/components/BranchTracker/RepoStatus.tsx
+++ b/src/components/BranchTracker/RepoStatus.tsx
@@ -1,19 +1,28 @@
 import React from 'react';
 import { v4 } from 'uuid';
+import { Add } from '@material-ui/icons';
 import { RootState } from '../../store/store';
 import { StyledTreeItem } from '../StyledTreeComponent';
 import { GitRepoIcon } from '../GitIcons';
-import { useAppSelector } from '../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import branchSelectors from '../../store/selectors/branches';
 import { Repository } from '../../store/slices/repos';
 import BranchStatus from './BranchStatus';
+import { modalAdded } from '../../store/slices/modals';
 
 const RepoStatus = (props: { repo: Repository; }) => {
     const branches = useAppSelector((state: RootState) => branchSelectors.selectByRepo(state, props.repo, true));
+    const dispatch = useAppDispatch();
 
     return (
         <StyledTreeItem key={props.repo.id} nodeId={props.repo.id} labelText={props.repo.name} labelIcon={GitRepoIcon}>
             {branches.filter(branch => branch.ref !== 'HEAD').map(branch => <BranchStatus key={v4()} repo={props.repo} branch={branch} />)}
+            <StyledTreeItem
+                key={`${props.repo}-newBranch`}
+                nodeId={`${props.repo}-newBranch`}
+                labelText={`[new branch]`}
+                labelIcon={Add}
+                onClick={() => dispatch(modalAdded({ id: v4(), type: 'NewBranchDialog', target: props.repo.id }))} />
         </StyledTreeItem>
     );
 };

--- a/src/components/Modal/ModalComponent.tsx
+++ b/src/components/Modal/ModalComponent.tsx
@@ -9,6 +9,7 @@ import MergeDialog from './MergeDialog';
 import NewCardDialog from './NewCardDialog';
 import Notification from './Notification';
 import SourcePickerDialog from './SourcePickerDialog';
+import NewBranchDialog from './NewBranchDialog';
 
 const ModalComponent = (props: Modal) => {
   switch (props.type) {
@@ -22,6 +23,8 @@ const ModalComponent = (props: Modal) => {
       return props.target ? (<GitGraph repo={props.target} />) : null;
     case 'MergeSelector':
       return (<MergeDialog {...props} />)
+    case 'NewBranchDialog':
+      return (<NewBranchDialog {...props} />);
     case 'NewCardDialog':
       return (<NewCardDialog {...props} />);
     case 'SourcePicker':

--- a/src/components/Modal/NewBranchDialog.tsx
+++ b/src/components/Modal/NewBranchDialog.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { Button, Dialog, Divider, Grid, TextField, Typography } from '@material-ui/core';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { Modal, modalRemoved } from '../../store/slices/modals';
+import { RootState } from '../../store/store';
+import branchSelectors from '../../store/selectors/branches';
+import repoSelectors from '../../store/selectors/repos';
+// import { createBranch } from '../../store/thunks/branches';
+import { branch } from '../../containers/git-porcelain';
+import { createBranch } from '../../store/thunks/branches';
+import { repoUpdated } from '../../store/slices/repos';
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        root: {
+            width: '100%',
+            maxWidth: 530,
+            backgroundColor: theme.palette.background.paper,
+        },
+        formControl1: {
+            margin: theme.spacing(1),
+            minWidth: 496
+        },
+        formControl2: {
+            margin: theme.spacing(1),
+            minWidth: 240,
+        },
+        button: {
+            margin: theme.spacing(1),
+        },
+        timeline: {
+            margin: theme.spacing(1),
+            '& > :last-child .MuiTimelineItem-content': {
+                height: 28
+            }
+        },
+        tl_item: {
+            padding: theme.spacing(0, 2),
+            '&:before': {
+                flex: 0,
+                padding: theme.spacing(0)
+            }
+        },
+        tl_content: {
+            padding: theme.spacing(0.5, 1, 0),
+        },
+        section1: {
+            margin: theme.spacing(3, 2, 1),
+        },
+        section2: {
+            margin: theme.spacing(1, 1),
+        },
+        section3: {
+            margin: theme.spacing(1, 1),
+        },
+    }),
+);
+
+const NewBranchDialog = (props: Modal) => {
+    const classes = useStyles();
+    const dispatch = useAppDispatch();
+    const repo = useAppSelector((state: RootState) => repoSelectors.selectById(state, props.target ? props.target : ''));
+    const branches = repo ? useAppSelector((state: RootState) => branchSelectors.selectByRepo(state, repo, true)) : undefined;
+    const [branchName, setBranchName] = React.useState('');
+    const isNoneDuplicate = !branches?.find(b => b.ref === branchName);
+
+    const isCreateReady = () => (branchName.length > 0 && isNoneDuplicate) ? true : false;
+    const handleBranchNameChange = (event: React.ChangeEvent<HTMLInputElement>) => setBranchName(event.target.value);
+    const handleClose = () => dispatch(modalRemoved(props.id));
+    const handleClick = async () => {
+        if (repo) {
+            const root = await branch({ dir: repo.root, repo: repo, ref: branchName });
+            const newBranch = await dispatch(createBranch({ root, branch: branchName, scope: 'local' })).unwrap();
+            dispatch(repoUpdated({ ...repo, local: [...repo.local, newBranch.id] }));
+        }
+        handleClose();
+    };
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            handleClick();
+        }
+    }
+
+    return (
+        <Dialog id='new-branch-dialog' data-testid='new-branch-dialog' open={true} onClose={handleClose} aria-labelledby='new-branch-dialog'>
+            <div className={classes.root}>
+                <div className={classes.section1}>
+                    <Grid container alignItems='center'>
+                        <Grid item xs>
+                            <Typography gutterBottom variant='h4'>
+                                New Branch
+                            </Typography>
+                        </Grid>
+                        <Grid item>
+                        </Grid>
+                    </Grid>
+                    <Typography color='textSecondary' variant='body2'>
+                        Provide a name for the new branch.
+                    </Typography>
+                </div>
+                <Divider variant='middle' />
+                <div className={classes.section2}>
+                    <TextField
+                        id='new-branch-name'
+                        variant='outlined'
+                        className={classes.formControl2}
+                        label='Branch Name'
+                        value={branchName}
+                        onChange={handleBranchNameChange}
+                        onKeyDown={(e) => handleKeyDown(e)}
+                        error={branchName.length > 0 && !isNoneDuplicate}
+                        helperText={(branchName.length > 0 && !isNoneDuplicate) ? 'Branch name already exists' : ''}
+                    />
+                </div>
+                <div className={classes.section3}>
+                    <Button id='create-branch-button'
+                        className={classes.button}
+                        data-testid='create-branch-button'
+                        variant='outlined'
+                        color='primary'
+                        disabled={!isCreateReady()}
+                        onClick={handleClick}
+                    >Create Branch</Button>
+                </div>
+            </div>
+        </Dialog>
+    );
+};
+
+export default NewBranchDialog;

--- a/src/containers/git-plumbing.ts
+++ b/src/containers/git-plumbing.ts
@@ -10,7 +10,7 @@ import { toHTTPS } from 'git-remote-protocol';
 // import { isHiddenFile } from 'is-hidden-file';
 import * as io from './io';
 import * as worktree from './git-worktree';
-import { currentBranch } from './git-porcelain';
+import { currentBranch, log } from './git-porcelain';
 import { AtLeastOne, removeUndefinedProperties } from './format';
 import { unstage } from './unstage-shim';
 import { getRoot, getWorktreePaths } from './git-path';

--- a/src/containers/git-plumbing.ts
+++ b/src/containers/git-plumbing.ts
@@ -97,12 +97,14 @@ export const resolveURL = (url: string): string => {
 
 /**
  * Get the value of a symbolic ref or resolve a ref to its SHA-1 object id; this is a wrapper to the *isomorphic-git/resolveRef* function 
- * to inject the `fs` parameter and extend with additional worktree path resolving functionality. If the `gitdir` parameter is a file, then
+ * to inject the `fs` parameter and extend with additional worktree path resolving functionality and special identifier
+ * support (i.e. `HEAD` for the current commit, `HEAD~1` for the previous commit). If the `gitdir` parameter is a file, then
  * `.git` points to a file containing updated pathing to translate from the linked worktree to the main worktree and must be resolved 
  * before any refs can be resolved.
+ * Ref: https://github.com/isomorphic-git/isomorphic-git/issues/1238#issuecomment-871220830
  * @param dir The working tree directory path.
  * @param gitdir The git directory path.
- * @param ref The ref to resolve.
+ * @param ref The git ref or symbolic-ref (i.e. `HEAD` or `HEAD~1`) to resolve against the current branch.
  * @param depth How many symbolic references to follow before returning.
  * @return A Promise object containing the SHA-1 hash or branch name associated with the given `ref` depending on the `depth` parameter; 
  * e.g. `ref: 'HEAD', depth: 2` returns the current branch name, `ref: 'HEAD', depth: 1` returns the SHA-1 hash of the current commit 
@@ -115,11 +117,20 @@ export const resolveRef = async ({ dir, gitdir = path.join(dir.toString(), '.git
   depth?: number;
 }): Promise<string> => {
   const worktree = await getWorktreePaths(dir);
-  const optional = removeUndefinedProperties({ depth: depth });
+  const re = /^HEAD~([0-9]+)$/;
+  const match = ref.match(re);
+  if (match) {
+    const count = +match[1];
+    const root = worktree.worktreeDir ? worktree.worktreeDir.toString() : worktree.dir ? worktree.dir.toString() : dir;
+    const commits = await log({ dir: root, depth: count + 1 });
+    const oid = commits.pop()?.oid;
+    if (oid) return oid;
+  }
   if (worktree.gitdir && worktree.worktreeLink && ref === 'HEAD') {
     const linkedRef = (await io.readFileAsync(path.join(worktree.worktreeLink.toString(), 'HEAD'), { encoding: 'utf-8' })).slice('ref: '.length).trim();
     return (await io.readFileAsync(path.join(worktree.gitdir.toString(), linkedRef), { encoding: 'utf-8' })).trim();
   }
+  const optional = removeUndefinedProperties({ depth: depth });
   return await isogit.resolveRef({ fs: fs, dir: dir.toString(), gitdir: gitdir.toString(), ref: ref, ...optional });
 }
 

--- a/src/containers/git-porcelain.ts
+++ b/src/containers/git-porcelain.ts
@@ -96,8 +96,8 @@ export const clone = async ({ dir, url, repo, ref, singleBranch = false, noCheck
  * @returns A Promise object for the checkout operation.
  */
 export const checkout = async ({
-  dir, gitdir = path.join(dir.toString(), '.git'), ref = 'HEAD', filepaths, remote = 'origin',
-  noCheckout = false, noUpdateHead = ref === undefined, dryRun = false, force = false, onProgress
+  dir, gitdir = path.join(dir.toString(), '.git'), ref = 'HEAD', filepaths, remote = 'origin', noCheckout = false,
+  noUpdateHead = ref === undefined, dryRun = false, force = false, track = true, onProgress
 }: {
   dir: fs.PathLike;
   gitdir?: fs.PathLike;
@@ -108,12 +108,13 @@ export const checkout = async ({
   noUpdateHead?: boolean;
   dryRun?: boolean;
   force?: boolean;
+  track?: boolean;
   onProgress?: isogit.ProgressCallback;
 }): Promise<void> => {
-  const optionals = removeUndefinedProperties({ filepaths: filepaths, onProgress: onProgress });
+  const optionals = removeUndefinedProperties({ filepaths, onProgress });
   return isogit.checkout({
     fs: fs, dir: dir.toString(), gitdir: gitdir.toString(), ref: ref, remote: remote, noCheckout: noCheckout,
-    noUpdateHead: noUpdateHead, dryRun: dryRun, force: force, ...optionals
+    noUpdateHead: noUpdateHead, dryRun: dryRun, force: force, track: track, ...optionals
   });
 }
 
@@ -151,7 +152,7 @@ export const commit = async ({ dir, gitdir = path.join(dir.toString(), '.git'), 
   parent?: Array<string>;
   tree?: string;
 }): Promise<string> => {
-  const optionals = removeUndefinedProperties({ author: author, committer: committer, signingKey: signingKey, ref: ref, parent: parent, tree: tree });
+  const optionals = removeUndefinedProperties({ author, committer, signingKey, ref, parent, tree });
   return isogit.commit({
     fs: fs, dir: dir.toString(), gitdir: gitdir.toString(), message: message, dryRun, noUpdateBranch, ...optionals
   });
@@ -174,7 +175,7 @@ export const currentBranch = async ({ dir, gitdir = path.join(dir.toString(), '.
   fullname?: boolean;
   test?: boolean;
 }): Promise<string | void> => {
-  const optionals = removeUndefinedProperties({ fullname: fullname, test: test });
+  const optionals = removeUndefinedProperties({ fullname, test });
   const worktree = await getWorktreePaths(gitdir);
   return worktree.worktreeLink
     ? isogit.currentBranch({ fs: fs, dir: worktree.worktreeLink.toString(), gitdir: worktree.worktreeLink.toString(), ...optionals })

--- a/src/containers/git-porcelain.ts
+++ b/src/containers/git-porcelain.ts
@@ -63,9 +63,10 @@ export const clone = async ({ dir, url, repo, ref, singleBranch = false, noCheck
     const targetBranch = ref ? ref : existingBranch;
 
     if (targetBranch && !remoteBranches.includes(targetBranch)) {
-      // cloning a local-only branch via copy & checkout
+      // cloning a local-only branch via copy & branch
       await fs.copy(repo.root.toString(), dir.toString(), { filter: path => !(path.indexOf('node_modules') > -1) }); // do not copy node_modules/ directory
-      await checkout({ dir: dir, ref: targetBranch, noCheckout: noCheckout });
+      await isogit.branch({ fs: fs, dir: dir.toString(), ref: targetBranch, checkout: false });
+      if (!noCheckout) await checkout({ dir: dir, ref: targetBranch, track: false });
       return true;
     } else {
       // cloning an existing repository into a linked worktree root directory
@@ -86,7 +87,7 @@ export const clone = async ({ dir, url, repo, ref, singleBranch = false, noCheck
  * @param ref The branch name or SHA-1 commit hash to checkout files from; defaults to `HEAD`.
  * @param filepaths Limit the checkout to the given files and directories.
  * @param remote Which remote repository to use for the checkout process; defaults to `origin`.
- * @param noCheckout Optional flag to udate HEAD but not update the working directory; defaults to `false`.
+ * @param noCheckout Optional flag to update HEAD but not update the working directory; defaults to `false`.
  * @param noUpdateHead Optional flag to update the working directory but not update HEAD. Defaults to `false` when `ref` is provided, 
  * and `true` if `ref` is not provided.
  * @param dryRun Optional flag to simulate a checkout in order to test whether it would succeed; defaults to `false`.

--- a/src/containers/git-porcelain.ts
+++ b/src/containers/git-porcelain.ts
@@ -16,26 +16,6 @@ import { GitStatus } from '../store/types';
 export type GitConfig = { scope: 'none' } | { scope: 'local' | 'global', value: string, origin?: string };
 
 /**
- * Get the value of a symbolic ref or resolve a ref to its SHA1 object id; this function is a wrapper to the 
- * *isomorphic-git/resolveRef* function to inject the `fs` parameter and extend with additional special identifier
- * support (i.e. `HEAD` for the current commit, `HEAD~1` for the previous commit).
- * Ref: https://github.com/isomorphic-git/isomorphic-git/issues/1238#issuecomment-871220830
- * @param dir The relative or absolute path to the git root (i.e. `/Users/nelsonni/scratch/project`).
- * @param ref The git ref or symbolic-ref (i.e. `HEAD` or `HEAD~1`) to resolve against the current branch.
- * @returns A Promise object containing the SHA1 commit resolved from the provided ref, or undefined if no commit found.
- */
-export const resolveRef = async (dir: fs.PathLike, ref: string): Promise<string | undefined> => {
-  const re = /^HEAD~([0-9]+)$/;
-  const match = ref.match(re);
-  if (match) {
-    const count = +match[1];
-    const commits = await isogit.log({ dir: dir.toString(), fs, depth: count + 1 });
-    return commits.pop()?.oid;
-  }
-  return isogit.resolveRef({ dir: dir.toString(), fs, ref });
-}
-
-/**
  * Clone a repository; this function is a wrapper to the *isomorphic-git/clone* function to inject the `fs` parameter and extend with
  * additional local-only branch functionality. If the `ref` parameter or the current branch do not exist on the remote repository, then the
  * local-only repository (including the *.git* directory) is copied using the *fs.copy* function (excluding the `node_modules` directory).

--- a/src/containers/git-worktree.spec.ts
+++ b/src/containers/git-worktree.spec.ts
@@ -169,7 +169,6 @@ describe('containers/git-worktree.add', () => {
                     refs: {
                         heads: {
                             master: 'f39895c492e97f23d9ce252afefca347a656a4b2\n',
-                            hotfix: '6b35cb455b16b0d0247c9cfdcb4982a4de599b23\n'
                         },
                         tags: {}
                     }
@@ -202,7 +201,7 @@ describe('containers/git-worktree.add', () => {
             corsProxy: new URL('http://www.oregonstate.edu').toString(),
             url: parsePath('https://github.com/sampleUser/baseRepo').toString(),
             default: 'master',
-            local: ['master', 'hotfix'],
+            local: ['master'],
             remote: [],
             oauth: 'github',
             username: 'sampleUser',
@@ -214,7 +213,7 @@ describe('containers/git-worktree.add', () => {
             .resolves.toBe(`gitdir: ${path.join('baseRepo', '.git', 'worktrees', 'hotfix')}\n`);
         await expect(readFileAsync('baseRepo/.git/worktrees/hotfix/HEAD', { encoding: 'utf-8' })).resolves.toBe('ref: refs/heads/hotfix\n');
         await expect(readFileAsync('baseRepo/.git/worktrees/hotfix/ORIG_HEAD', { encoding: 'utf-8' }))
-            .resolves.toBe('6b35cb455b16b0d0247c9cfdcb4982a4de599b23\n');
+            .resolves.toBe('f39895c492e97f23d9ce252afefca347a656a4b2\n');
         await expect(readFileAsync('baseRepo/.git/worktrees/hotfix/commondir', { encoding: 'utf-8' }))
             .resolves.toBe(`${path.normalize('../..')}\n`);
         await expect(readFileAsync('baseRepo/.git/worktrees/hotfix/gitdir', { encoding: 'utf-8' }))

--- a/src/containers/merges.ts
+++ b/src/containers/merges.ts
@@ -3,8 +3,7 @@ import util from 'util';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as isogit from 'isomorphic-git';
-import { resolveRef } from './git-porcelain';
-import { branchLog } from './git-plumbing';
+import { branchLog, resolveRef } from './git-plumbing';
 import { getWorktreePaths } from './git-path';
 import { extractStats } from './io';
 
@@ -42,7 +41,7 @@ export const merge = async (dir: fs.PathLike, base: string, compare: string): Pr
 
     const commitDelta = root ? await branchLog(root, base, compare) : [];
     if (root && commitDelta.length == 0) {
-        const oid = worktree.dir ? await resolveRef(worktree.dir, 'HEAD') : '';
+        const oid = worktree.dir ? await resolveRef({ dir: worktree.dir, ref: 'HEAD' }) : '';
         return {
             mergeStatus: {
                 oid: oid ? oid : '',
@@ -64,7 +63,7 @@ export const merge = async (dir: fs.PathLike, base: string, compare: string): Pr
         const conflictPattern = /(?<=conflict in ).*(?=\n)/gm;
         const mergeOutput = mergeError ? `${mergeError.stdout}\n${mergeError.stderr}` : '';
         const conflicts = mergeOutput.match(conflictPattern)?.map(filename => worktree.dir ? path.resolve(worktree.dir.toString(), filename) : filename);
-        const oid = worktree.dir ? await resolveRef(worktree.dir, 'HEAD') : '';
+        const oid = worktree.dir ? await resolveRef({ dir: worktree.dir, ref: 'HEAD' }) : '';
         return {
             mergeStatus: {
                 oid: oid ? oid : '',
@@ -77,7 +76,7 @@ export const merge = async (dir: fs.PathLike, base: string, compare: string): Pr
             stderr: mergeError.stderr
         };
     }
-    const oid = worktree.dir ? await resolveRef(worktree.dir, 'HEAD') : '';
+    const oid = worktree.dir ? await resolveRef({ dir: worktree.dir, ref: 'HEAD' }) : '';
     return {
         mergeStatus: {
             oid: oid ? oid : '',

--- a/src/store/slices/branches.ts
+++ b/src/store/slices/branches.ts
@@ -9,10 +9,11 @@ export type Branch = {
     readonly id: UUID;
     /** The name of branch. */
     readonly ref: string;
-    /** The relative or absolute path to the working tree directory path. This is the worktree root directory in the case of linked worktrees,
+    /** The relative or absolute path to the working tree directory path. This is the worktree directory in the case of linked worktrees,
      * and the parent of the root directory (.git) in the main worktree otherwise. */
     readonly root: PathLike;
-    /** The relative or absolute path to the git root directory (.git) in the main worktree. */
+    /** The relative or absolute path to the git root directory (.git) in the working tree directory path. This is the worktree root directory 
+     * in the case of linked worktrees, and the main worktree git directory in the main worktree otherwise. */
     readonly gitdir: PathLike;
     /** The reference scope of the branch; typically a branch will have an instance of both a `local` and `remote` branch. */
     readonly scope: 'local' | 'remote';

--- a/src/store/slices/repos.ts
+++ b/src/store/slices/repos.ts
@@ -2,7 +2,6 @@ import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { PURGE } from 'redux-persist';
 import { isDefined } from '../../containers/format';
-// import { fetchNewRepo } from '../thunks/repos';
 import { UUID } from '../types';
 import { branchRemoved } from './branches';
 
@@ -50,9 +49,6 @@ export const repoSlice = createSlice({
     },
     extraReducers: (builder) => {
         builder
-            // .addCase(fetchNewRepo.fulfilled, (state, action) => {
-            //     reposAdapter.addOne(state, action.payload);
-            // })
             .addCase(branchRemoved, (state, action) => {
                 const updatedRepos = Object.values(state.entities)
                     .filter(isDefined)

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -42,4 +42,5 @@ export type GitStatus = 'modified' | 'ignored' | 'unmodified' | '*modified' | '*
  */
 export type FilesystemStatus = 'modified' | 'unmodified' | 'unlinked';
 export type CardType = 'Loading' | 'Editor' | 'Diff' | 'Explorer' | 'Browser' | 'BranchTracker' | 'Merge' | 'SourceControl' | 'ConflictManager';
-export type ModalType = 'BranchList' | 'CloneSelector' | 'DiffPicker' | 'Error' | 'GitGraph' | 'MergeSelector' | 'NewCardDialog' | 'SourcePicker' | 'CommitDialog' | 'Notification';
+export type ModalType = 'BranchList' | 'CloneSelector' | 'DiffPicker' | 'Error' | 'GitGraph' | 'MergeSelector' | 'NewBranchDialog' | 'NewCardDialog' |
+    'SourcePicker' | 'CommitDialog' | 'Notification';


### PR DESCRIPTION
### **Description**:

Users typically require the ability to create additional branches within version-controlled projects. This functionality is required as part of upcoming user studies as well.

The new [`NewBranchDialog`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/components/Modal/NewBranchDialog.tsx) provides the ability to set a unique name and create a new branch within the repository that it was launched from; this modal dialog is only launched from within [`RepoStatus`
](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/components/BranchTracker/RepoStatus.tsx) components inside of `BranchTracker` cards.

This PR resolves #721, and signifies a **MINOR** version increase (per [Semantic Version](https://semver.org/)).

### **Changes**:

This PR makes the following changes:
* Adds [`NewBranchDialog`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/components/Modal/NewBranchDialog.tsx) modal dialog for capturing and validating the new branch name.
* Adds [`git-porcelain.branch`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/containers/git-porcelain.ts#L19-L49) command for creating new branches in a repository.
* Fixes [`git-porcelain.clone`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/containers/git-porcelain.ts#L51-L114) command to allow local-only branches during subsequent checkouts.
* Fixes [`git-porcelain.checkout`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/containers/git-porcelain.ts#L116-L152) command to include support for `track` parameter added in [`isomorphic-git/isomorphic-git` v1.11.0](https://github.com/isomorphic-git/isomorphic-git/releases/tag/v1.11.0).
* Removes `git-porcelain.resolveRef` command in favor of using an expanded [`git-plumbing.resolveRef`](https://github.com/EPICLab/synectic/blob/97a36e2095b7f9f3891b1f0187076acf9b963813/src/containers/git-plumbing.ts#L98-L135) command.

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.

