### PR TITLE
Use TS 4.7 Instantiation Expressions for filterObject return type

### DIFF
--- a/src/containers/utils.ts
+++ b/src/containers/utils.ts
@@ -163,7 +163,7 @@ export const asyncFilter = async <T>(arr: T[], predicate: (e: T) => Promise<bool
  * @param filter An array of key strings that indicate which key-value pairs should be included or excluded.
  * @return The resulting object devoid of key-value fields that did not match the key filter, or an empty object.
  */
-export const filterObject = <V, T extends Record<string, V>>(obj: T, filter: string[]): T | Record<string, never> => {
+export const filterObject = <V, T extends Record<string, V>>(obj: T, filter: string[]): ReturnType<typeof flattenObject<T>> => {
   return Object.entries(flattenObject(obj))
     .filter(([key]) => filter.includes(key))
     .reduce((accumulator, [k, v]) => ({ ...accumulator, [k]: v }), {});


### PR DESCRIPTION
### **Description**:

#787 updated [typescript](https://github.com/Microsoft/TypeScript) to 4.7, which included [_Instantiation Expressions_](https://github.com/microsoft/TypeScript/pull/47607), which allows us to update the return type of [`filterObject()`](https://github.com/EPICLab/synectic/blob/362f1dbdbe19f126ed2c8665401909548031ff2c/src/containers/utils.ts#L166-L170) to use a pass-through generic reference `T` for discerning the expected return based on the return type of [`flattenObject`](https://github.com/EPICLab/synectic/blob/68281d04e4f65f0fc90cbedf4412d807b907e371/src/containers/flatten.ts#L37-L47) (as outlined in #699).

This PR resolves #699, and signifies a **MINOR** version increase (per [Semantic Version](https://semver.org/)).

### **Changes**:

This PR makes the following changes:
* Updates [`filterObject()`](https://github.com/EPICLab/synectic/blob/68281d04e4f65f0fc90cbedf4412d807b907e371/src/containers/flatten.ts#L37-L47) to use `ReturnType<typeof flattenObject<T>>` for indicating that all

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.

