### PR TITLE
Fail only on error messages in `stderr` output stream for `cloneRepo` command

### DIFF
--- a/src/containers/git/git-clone.ts
+++ b/src/containers/git/git-clone.ts
@@ -1,4 +1,4 @@
-import { PathLike } from 'fs-extra';
+import { pathExists, PathLike } from 'fs-extra';
 import { dirname } from 'path';
 import { execute } from '../utils';
 
@@ -33,6 +33,7 @@ export const cloneRepo = async ({
     noCheckout?: boolean;
 }): Promise<boolean> => {
     const parentDir = dirname(dir.toString()); // the `dir` directory doesn't exist yet, so start from parent
+    if (!(await pathExists(parentDir))) throw new Error(`ENOENT: no such file or directory, clone attempted in '${parentDir}'`);
     const bareOption = bare ? `--bare` : '';
     const noCheckoutOption = noCheckout ? `--no-checkout` : '';
     const singleBranchOption = singleBranch ? `--single-branch` : '';

--- a/src/containers/git/git-clone.ts
+++ b/src/containers/git/git-clone.ts
@@ -1,6 +1,6 @@
 import { pathExists, PathLike } from 'fs-extra';
 import { dirname } from 'path';
-import { execute } from '../utils';
+import { execute, isDefined } from '../utils';
 
 /**
  * Clone a repository into a new directory.
@@ -40,13 +40,11 @@ export const cloneRepo = async ({
     const branchOption = branch ? `--branch ${branch}` : '';
     const output = await execute(`git clone ${repo.toString()} ${dir.toString()} ${branchOption} ${bareOption} ${noCheckoutOption} ${singleBranchOption}`, parentDir.toString());
 
-    if (output.stderr.length > 0) {
+    const successfulClonePattern = new RegExp(/Cloning into '.*'.../, 'g');
+    if (output.stderr.length > 0 && (output.stderr.split(/\\r?\\n/).length > 1 || successfulClonePattern.test(output.stderr) === false)) {
         console.error(output.stderr);
         return false;
     }
-    if (output.stdout.length > 0) {
-        console.log(output.stdout);
-        return true;
-    }
-    return false;
+    console.log(output.stdout);
+    return true;
 }

--- a/src/containers/git/git-clone.ts
+++ b/src/containers/git/git-clone.ts
@@ -1,6 +1,6 @@
 import { pathExists, PathLike } from 'fs-extra';
 import { dirname } from 'path';
-import { execute, isDefined } from '../utils';
+import { execute } from '../utils';
 
 /**
  * Clone a repository into a new directory.


### PR DESCRIPTION
### **Description**:

Changes default behavior of [`cloneRepo`](https://github.com/EPICLab/synectic/blob/56c745a6370c521922f5eab6b12338b69c1a851d/src/containers/git/git-clone.ts#L5-L51) to return `true` unless the `stderr` output stream contains error or warning messages besides the `Cloning into '.*'...` pattern indicated for successful cloning.

This PR resolves #968, and signifies the following version changes (per [Semantic Version](https://semver.org/)):
* **PATCH** version increase

### **Changes**:

This PR makes the following changes:
* Checkout `stderr` output stream of `git clone` command in [`cloneRepo`](https://github.com/EPICLab/synectic/blob/56c745a6370c521922f5eab6b12338b69c1a851d/src/containers/git/git-clone.ts#L5-L51) to determine if error or warning messages besides the `Cloning into '.*'...` pattern appeared (which would indicate a failed clone operation).
* Throw `ENOENT` error on non-existent parent directory for `dir` parameter to [`cloneRepo`](https://github.com/EPICLab/synectic/blob/56c745a6370c521922f5eab6b12338b69c1a851d/src/containers/git/git-clone.ts#L5-L51)

### **Checklist**:

Before submitting this PR, I have verified that my code:
* [X] Resides on a `fix/` or `feature/` branch that was initially branched off from `development`.
* [X] Passes code linting (`yarn lint`) and unit testing (`yarn test`).
* [X] Successfully builds a distribution package (`yarn package`).
* [X] I have read and am aware of the [CONTRIBUTING](CONTRIBUTING.md) guide for this project.
* [X] My name is listed in the [Contributors](README.md#contributors) section, or this PR includes a request to add my name.

