### PR TITLE
Use `createAsyncThunk.withTypes<>()` from RTK 1.9 for pre-typed `createAsyncThunk`

### DIFF
--- a/src/containers/dialogs.ts
+++ b/src/containers/dialogs.ts
@@ -1,7 +1,6 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ipcRenderer } from 'electron';
 import { join } from 'path';
-import { AppThunkAPI } from '../store/hooks';
+import { createAppAsyncThunk } from '../store/hooks';
 import { isFilebasedMetafile, Metafile, metafileUpdated } from '../store/slices/metafiles';
 import { buildCard } from '../store/thunks/cards';
 import { writeFileAsync } from './io';
@@ -11,7 +10,7 @@ import metafileSelectors from '../store/selectors/metafiles';
 
 type PickerType = 'openFile' | 'openDirectory';
 
-export const fileOpenDialog = createAsyncThunk<void, PickerType | void, AppThunkAPI>(
+export const fileOpenDialog = createAppAsyncThunk<void, PickerType | void>(
   'dialogs/fileOpenDialog',
   async (pickerType, thunkAPI) => {
     const isMac = process.platform === 'darwin';
@@ -32,7 +31,7 @@ export const fileOpenDialog = createAsyncThunk<void, PickerType | void, AppThunk
   }
 );
 
-export const fileSaveDialog = createAsyncThunk<boolean, Metafile, AppThunkAPI>(
+export const fileSaveDialog = createAppAsyncThunk<boolean, Metafile>(
   'dialogs/fileSaveDialog',
   async (metafile, thunkAPI) => {
     const isMac = process.platform === 'darwin';
@@ -56,7 +55,7 @@ export const fileSaveDialog = createAsyncThunk<boolean, Metafile, AppThunkAPI>(
   }
 );
 
-export const cloneDirectoryDialog = createAsyncThunk<string | null, string, AppThunkAPI>(
+export const cloneDirectoryDialog = createAppAsyncThunk<string | null, string>(
   'dialogs/cloneDirectoryDialog',
   async (repoName) => {
     const isMac = process.platform === 'darwin';

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,7 +1,12 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import type { RootState, AppDispatch } from './store';
 
-export type AppThunkAPI<R = unknown> = { state: RootState, dispatch: AppDispatch, rejectValue: R };
+export const createAppAsyncThunk = createAsyncThunk.withTypes<{
+    state: RootState,
+    dispatch: AppDispatch,
+    rejectValue: string
+}>();
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/thunks/branches.ts
+++ b/src/store/thunks/branches.ts
@@ -1,11 +1,10 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { normalize } from 'path';
 import { v4 } from 'uuid';
 import isBoolean from 'validator/lib/isBoolean';
 import { deleteBranch, fetchMergingBranches, getBranchRoot, getConfig, getRoot, getWorktreePaths, listBranch, log, revParse, worktreeAdd, worktreeList, worktreeRemove, worktreeStatus } from '../../containers/git';
 import { ExactlyOne, isDefined, removeObjectProperty } from '../../containers/utils';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import branchSelectors from '../selectors/branches';
 import repoSelectors from '../selectors/repos';
 import { Branch, branchAdded, branchReplaced, isMergingBranch } from '../slices/branches';
@@ -16,7 +15,7 @@ import { fetchParentMetafile } from './metafiles';
 
 type BranchIdentifiers = { root: PathLike, branch: string, scope: 'local' | 'remote' };
 
-export const fetchBranch = createAsyncThunk<Branch | undefined, ExactlyOne<{ branchIdentifiers: BranchIdentifiers, metafile: FilebasedMetafile }>, AppThunkAPI>(
+export const fetchBranch = createAppAsyncThunk<Branch | undefined, ExactlyOne<{ branchIdentifiers: BranchIdentifiers, metafile: FilebasedMetafile }>>(
     'branches/fetchBranch',
     async (input, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -47,7 +46,7 @@ export const fetchBranch = createAsyncThunk<Branch | undefined, ExactlyOne<{ bra
     }
 );
 
-export const fetchBranches = createAsyncThunk<{ local: Branch[], remote: Branch[] }, PathLike, AppThunkAPI>(
+export const fetchBranches = createAppAsyncThunk<{ local: Branch[], remote: Branch[] }, PathLike>(
     'branches/fetchBranches',
     async (root, thunkAPI) => {
         const branches: Awaited<ReturnType<typeof listBranch>> = await listBranch({ dir: root, all: true });
@@ -69,7 +68,7 @@ export const fetchBranches = createAsyncThunk<{ local: Branch[], remote: Branch[
  * a repository worktree (i.e. it does not interact with the filesystem). Instead, this function updates the 
  * store state to reflect any newly created branches.
  */
-export const buildBranch = createAsyncThunk<Branch, BranchIdentifiers, AppThunkAPI>(
+export const buildBranch = createAppAsyncThunk<Branch, BranchIdentifiers>(
     'branches/buildBranch',
     async (identifiers, thunkAPI) => {
         const branchRoot: Awaited<ReturnType<typeof getBranchRoot>> = await getBranchRoot(identifiers.root, identifiers.branch);
@@ -112,7 +111,7 @@ export const buildBranch = createAsyncThunk<Branch, BranchIdentifiers, AppThunkA
  * @returns {Branch} A new Branch object representing the updated worktree information, or an existing Branch if `ref` matches
  * the existing current branch in the repository root directory.
  */
-export const addBranch = createAsyncThunk<Branch | undefined, { ref: string, root: PathLike }, AppThunkAPI>(
+export const addBranch = createAppAsyncThunk<Branch | undefined, { ref: string, root: PathLike }>(
     'branches/addBranch',
     async ({ ref, root }, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -153,7 +152,7 @@ export const addBranch = createAsyncThunk<Branch | undefined, { ref: string, roo
  * @param obj.branch - The name of the branch to remove.
  * @returns {boolean} A boolean indicating whether the branch was successfully removed.
  */
-export const removeBranch = createAsyncThunk<boolean, { repoId: UUID, branch: Branch }, AppThunkAPI>(
+export const removeBranch = createAppAsyncThunk<boolean, { repoId: UUID, branch: Branch }>(
     'branches/removeBranch',
     async ({ repoId, branch }, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -175,7 +174,7 @@ export const removeBranch = createAsyncThunk<boolean, { repoId: UUID, branch: Br
  * status of a branch. Also appends/removes merging information in the case of an in-progress merge where this branch
  * is the base. This function updates the store state to reflect any recent changes to these fields.
  */
-export const updateBranch = createAsyncThunk<Branch, Branch, AppThunkAPI>(
+export const updateBranch = createAppAsyncThunk<Branch, Branch>(
     'branches/updateBranch',
     async (branch, thunkAPI) => {
         const branchRoot = await getBranchRoot(branch.root, branch.ref);
@@ -198,7 +197,7 @@ export const updateBranch = createAsyncThunk<Branch, Branch, AppThunkAPI>(
  * added/removed branches so that the repository remains up-to-date with the state of branches in the underlying
  * git repository on the filesystem.
  */
-export const updateBranches = createAsyncThunk<Repository, Repository, AppThunkAPI>(
+export const updateBranches = createAppAsyncThunk<Repository, Repository>(
     'branches/updateBranches',
     async (repo, thunkAPI) => {
         const branches = await thunkAPI.dispatch(fetchBranches(repo.root)).unwrap();

--- a/src/store/thunks/cache.ts
+++ b/src/store/thunks/cache.ts
@@ -1,12 +1,11 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { readFileAsync } from '../../containers/io';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import cacheSelectors from '../selectors/cache';
 import { Cache, cacheRemoved, cacheUpdated } from '../slices/cache';
 import { UUID } from '../types';
 
-export const subscribe = createAsyncThunk<Cache, { path: PathLike, card: UUID }, AppThunkAPI>(
+export const subscribe = createAppAsyncThunk<Cache, { path: PathLike, card: UUID }>(
     'cache/subscribe',
     async ({ path, card }, thunkAPI) => {
         const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
@@ -20,14 +19,14 @@ export const subscribe = createAsyncThunk<Cache, { path: PathLike, card: UUID },
     }
 );
 
-export const subscribeAll = createAsyncThunk<Cache[], { paths: PathLike[], card: UUID }, AppThunkAPI>(
+export const subscribeAll = createAppAsyncThunk<Cache[], { paths: PathLike[], card: UUID }>(
     'cache/subscribeAll',
     async ({ paths, card }, thunkAPI) => {
         return await Promise.all(paths.map(async p => await thunkAPI.dispatch(subscribe({ path: p, card: card })).unwrap()));
     }
 );
 
-export const unsubscribe = createAsyncThunk<undefined, { path: PathLike, card: UUID }, AppThunkAPI>(
+export const unsubscribe = createAppAsyncThunk<undefined, { path: PathLike, card: UUID }>(
     'cache/unsubscribe',
     async ({ path, card }, thunkAPI) => {
         const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
@@ -42,7 +41,7 @@ export const unsubscribe = createAsyncThunk<undefined, { path: PathLike, card: U
     }
 );
 
-export const unsubscribeAll = createAsyncThunk<undefined, { paths: PathLike[], card: UUID }, AppThunkAPI>(
+export const unsubscribeAll = createAppAsyncThunk<undefined, { paths: PathLike[], card: UUID }>(
     'cache/unsubscribeAll',
     async ({ paths, card }, thunkAPI) => {
         paths.forEach(async p => await thunkAPI.dispatch(unsubscribe({ path: p, card: card })));

--- a/src/store/thunks/cards.ts
+++ b/src/store/thunks/cards.ts
@@ -1,15 +1,14 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { DateTime } from 'luxon';
 import { v4 } from 'uuid';
 import { ExactlyOne, getRandomInt } from '../../containers/utils';
 import { extractFilename } from '../../containers/io';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import { Card, cardAdded, cardUpdated } from '../slices/cards';
 import { Metafile } from '../slices/metafiles';
 import { createMetafile, fetchMetafile } from './metafiles';
 
-export const buildCard = createAsyncThunk<Card, ExactlyOne<{ path: PathLike, metafile: Metafile }>, AppThunkAPI>(
+export const buildCard = createAppAsyncThunk<Card, ExactlyOne<{ path: PathLike, metafile: Metafile }>>(
     'cards/buildCard',
     async (input, thunkAPI) => {
         let card: Card = thunkAPI.dispatch(cardAdded({
@@ -42,7 +41,7 @@ export const buildCard = createAsyncThunk<Card, ExactlyOne<{ path: PathLike, met
     }
 );
 
-export const addBranchCard = createAsyncThunk<Card, void, AppThunkAPI>(
+export const addBranchCard = createAppAsyncThunk<Card, void>(
     'cards/addBranchCard',
     async (_, thunkAPI) => {
         const metafile = await thunkAPI.dispatch(createMetafile({

--- a/src/store/thunks/filetypes.ts
+++ b/src/store/thunks/filetypes.ts
@@ -1,12 +1,11 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { v4 } from 'uuid';
 import { PathLike } from 'fs';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import { Filetype, filetypeAdded } from '../slices/filetypes';
 import { extractExtension, extractStats } from '../../containers/io';
 import filetypeSelectors from '../selectors/filetypes';
 
-export const fetchFiletype = createAsyncThunk<Filetype | undefined, PathLike, AppThunkAPI>(
+export const fetchFiletype = createAppAsyncThunk<Filetype | undefined, PathLike>(
     'filetypes/fetchFiletype',
     async (filepath, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -18,7 +17,7 @@ export const fetchFiletype = createAsyncThunk<Filetype | undefined, PathLike, Ap
     }
 );
 
-export const importFiletypes = createAsyncThunk<void, Omit<Filetype, 'id'>[], AppThunkAPI>(
+export const importFiletypes = createAppAsyncThunk<void, Omit<Filetype, 'id'>[]>(
     'filetypes/importFiletypes',
     async (filetypes, thunkAPI) => {
         filetypes.map(filetype => {

--- a/src/store/thunks/metafiles.ts
+++ b/src/store/thunks/metafiles.ts
@@ -1,4 +1,3 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import { DateTime } from 'luxon';
 import { dirname, join, relative } from 'path';
@@ -7,7 +6,7 @@ import { flattenArray } from '../../containers/flatten';
 import { checkoutPathspec, checkUnmergedPath, Conflict, fileStatus, getIgnore, getRoot, worktreeStatus } from '../../containers/git';
 import { extractFilename, isEqualPaths, readDirAsyncDepth, readFileAsync } from '../../containers/io';
 import { ExactlyOne, isDefined, isUpdateable, removeDuplicates, symmetrical } from '../../containers/utils';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import branchSelectors from '../selectors/branches';
 import metafileSelectors from '../selectors/metafiles';
 import { DirectoryMetafile, FilebasedMetafile, isDirectoryMetafile, isFilebasedMetafile, isFileMetafile, isVersionedMetafile, Metafile, metafileAdded, MetafileTemplate, metafileUpdated, VersionedMetafile } from '../slices/metafiles';
@@ -31,7 +30,7 @@ export const isHydrated = (metafile: Metafile): boolean => {
     return filebasedHydrated && versionedHydrated;
 }
 
-export const fetchMetafile = createAsyncThunk<Metafile, { path: PathLike, handlers?: CardType[] }, AppThunkAPI>(
+export const fetchMetafile = createAppAsyncThunk<Metafile, { path: PathLike, handlers?: CardType[] }>(
     'metafiles/fetchMetafile',
     async ({ path: filepath, handlers }, thunkAPI) => {
         const existing = handlers
@@ -41,7 +40,7 @@ export const fetchMetafile = createAsyncThunk<Metafile, { path: PathLike, handle
     }
 );
 
-export const createMetafile = createAsyncThunk<Metafile, ExactlyOne<{ path: PathLike, metafile: MetafileTemplate }>, AppThunkAPI>(
+export const createMetafile = createAppAsyncThunk<Metafile, ExactlyOne<{ path: PathLike, metafile: MetafileTemplate }>>(
     'metafiles/createMetafile',
     async (input, thunkAPI) => {
         const filetype = await thunkAPI.dispatch(fetchFiletype(input.path ?? '')).unwrap();
@@ -59,7 +58,7 @@ export const createMetafile = createAsyncThunk<Metafile, ExactlyOne<{ path: Path
     }
 );
 
-export const updateFilebasedMetafile = createAsyncThunk<FilebasedMetafile, FilebasedMetafile, AppThunkAPI>(
+export const updateFilebasedMetafile = createAppAsyncThunk<FilebasedMetafile, FilebasedMetafile>(
     'metafiles/updateFilebasedMetafile',
     async (metafile, thunkAPI) => {
         if (metafile.filetype === 'Directory') {
@@ -94,7 +93,7 @@ export const updateFilebasedMetafile = createAsyncThunk<FilebasedMetafile, Fileb
     }
 );
 
-export const updateVersionedMetafile = createAsyncThunk<VersionedMetafile | FilebasedMetafile, FilebasedMetafile, AppThunkAPI>(
+export const updateVersionedMetafile = createAppAsyncThunk<VersionedMetafile | FilebasedMetafile, FilebasedMetafile>(
     'metafiles/updateVersionedMetafile',
     async (metafile, thunkAPI) => {
         const repo = await thunkAPI.dispatch(fetchRepo({ metafile })).unwrap();
@@ -150,7 +149,7 @@ export const updateVersionedMetafile = createAsyncThunk<VersionedMetafile | File
     }
 );
 
-export const fetchParentMetafile = createAsyncThunk<DirectoryMetafile | undefined, FilebasedMetafile, AppThunkAPI>(
+export const fetchParentMetafile = createAppAsyncThunk<DirectoryMetafile | undefined, FilebasedMetafile>(
     'metafiles/fetchParent',
     async (metafile, thunkAPI) => {
         const metafiles: ReturnType<typeof metafileSelectors.selectByFilepath> = metafileSelectors.selectByFilepath(thunkAPI.getState(), dirname(metafile.path.toString()));
@@ -170,7 +169,7 @@ export const fetchParentMetafile = createAsyncThunk<DirectoryMetafile | undefine
  * @returns {Metafile | undefined} A new Metafile object pointing to the same file as the metafile referenced in the parameters except
  * rooted in the new worktree, or undefined if a linked worktred could not be created.
  */
-export const switchBranch = createAsyncThunk<Metafile | undefined, { metafileId: UUID, ref: string, root: PathLike }, AppThunkAPI>(
+export const switchBranch = createAppAsyncThunk<Metafile | undefined, { metafileId: UUID, ref: string, root: PathLike }>(
     'metafiles/switchBranch',
     async ({ metafileId, ref, root }, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -190,7 +189,7 @@ export const switchBranch = createAsyncThunk<Metafile | undefined, { metafileId:
     }
 );
 
-export const revertChanges = createAsyncThunk<void, VersionedMetafile, AppThunkAPI>(
+export const revertChanges = createAppAsyncThunk<void, VersionedMetafile>(
     'metafiles/revertUnmergedChanges',
     async (metafile, thunkAPI) => {
         const branch = await thunkAPI.dispatch(fetchBranch({ metafile })).unwrap();
@@ -204,7 +203,7 @@ export const revertChanges = createAsyncThunk<void, VersionedMetafile, AppThunkA
     }
 )
 
-export const updateConflicted = createAsyncThunk<Metafile[], Conflict[], AppThunkAPI>(
+export const updateConflicted = createAppAsyncThunk<Metafile[], Conflict[]>(
     'metafiles/fetchConflicted',
     async (conflicts, thunkAPI) => {
         const conflictedFiles = removeDuplicates(conflicts, (c1, c2) => isEqualPaths(c1.path, c2.path));

--- a/src/store/thunks/repos.ts
+++ b/src/store/thunks/repos.ts
@@ -1,18 +1,17 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { PathLike } from 'fs-extra';
 import parsePath from 'parse-path';
 import { v4 } from 'uuid';
 import { extractFromURL, extractRepoName, getConfig, getWorktreePaths, GitConfig, listBranch } from '../../containers/git';
 import { extractFilename } from '../../containers/io';
 import { ExactlyOne } from '../../containers/utils';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import repoSelectors from '../selectors/repos';
 import { FilebasedMetafile, isVersionedMetafile } from '../slices/metafiles';
 import { repoAdded, Repository } from '../slices/repos';
 import { fetchBranches } from './branches';
 import { fetchParentMetafile } from './metafiles';
 
-export const fetchRepo = createAsyncThunk<Repository | undefined, ExactlyOne<{ filepath: PathLike, metafile: FilebasedMetafile }>, AppThunkAPI>(
+export const fetchRepo = createAppAsyncThunk<Repository | undefined, ExactlyOne<{ filepath: PathLike, metafile: FilebasedMetafile }>>(
     'repos/fetchRepo',
     async (input, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -37,7 +36,7 @@ export const fetchRepo = createAsyncThunk<Repository | undefined, ExactlyOne<{ f
     }
 )
 
-export const buildRepo = createAsyncThunk<Repository, PathLike, AppThunkAPI>(
+export const buildRepo = createAppAsyncThunk<Repository, PathLike>(
     'repos/buildRepo',
     async (filepath, thunkAPI) => {
         const { dir } = await getWorktreePaths(filepath);

--- a/src/store/thunks/stacks.ts
+++ b/src/store/thunks/stacks.ts
@@ -1,15 +1,14 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { XYCoord } from 'react-dnd';
 import { DateTime } from 'luxon';
 import { v4 } from 'uuid';
 import { Stack, stackAdded, stackRemoved, stackUpdated } from '../slices/stacks';
 import { cardUpdated } from '../slices/cards';
 import { UUID } from '../types';
-import { AppThunkAPI } from '../hooks';
+import { createAppAsyncThunk } from '../hooks';
 import cardSelectors from '../selectors/cards';
 import stackSelectors from '../selectors/stacks';
 
-export const createStack = createAsyncThunk<Stack, { name: string, note: string, cards: UUID[] }, AppThunkAPI>(
+export const createStack = createAppAsyncThunk<Stack, { name: string, note: string, cards: UUID[] }>(
     'stacks/createStack',
     async (input, thunkAPI) => {
         const cards = cardSelectors.selectByIds(thunkAPI.getState(), input.cards);
@@ -32,7 +31,7 @@ export const createStack = createAsyncThunk<Stack, { name: string, note: string,
 );
 
 /** Add cards to an existing Stack object. */
-export const pushCards = createAsyncThunk<void, { stack: UUID, cards: UUID[] }, AppThunkAPI>(
+export const pushCards = createAppAsyncThunk<void, { stack: UUID, cards: UUID[] }>(
     'stacks/pushCards',
     async (input, thunkAPI) => {
         const state = thunkAPI.getState();
@@ -64,7 +63,7 @@ export const pushCards = createAsyncThunk<void, { stack: UUID, cards: UUID[] }, 
  * parameter is provide (in which case the card is arbitrarily positioned outside of the stack). If the `delta` parameter used, then the
  * `{x,y}` values can be gathered from `DropTargetMonitor.getDifferenceFromInitialOffset()`. 
  */
-export const popCards = createAsyncThunk<void, { cards: UUID[], delta?: XYCoord }, AppThunkAPI>(
+export const popCards = createAppAsyncThunk<void, { cards: UUID[], delta?: XYCoord }>(
     'stacks/pushCards',
     async (input, thunkAPI) => {
         const state = thunkAPI.getState();


### PR DESCRIPTION
Switch to using a [pre-typed `createAppAsyncThunk`](https://redux-toolkit.js.org/usage/usage-with-typescript#defining-a-pre-typed-createasyncthunk) to avoid having to manually define [`AsyncThunkConfig`](https://redux-toolkit.js.org/usage/usage-with-typescript#typing-the-thunkapi-object) type fields for each call to `createAsyncThunk`. This change takes advantage of the new `createAsyncThunk.withTypes<>()` introduced in [RTK 1.9](https://github.com/reduxjs/redux-toolkit/releases/tag/v1.9.0).

This PR resolves #1055.

### **Changes**:

This PR makes the following changes:
* Add pre-typed `createAppAsyncThunk` and remove `AppThunkAPI` type definition
* Switch all `createAsyncThunk` calls to use the pre-typed `createAppAsyncThunk`