### PR TITLE
Fetch `Cache` state with `useAppDispatch` in `FSCache` update event handler

### DIFF
--- a/src/store/cache/FSCache.tsx
+++ b/src/store/cache/FSCache.tsx
@@ -10,7 +10,7 @@ import cacheSelectors from '../selectors/cache';
 import { diffArrays } from 'diff';
 import { flattenArray } from '../../containers/flatten';
 import { cacheRemoved, cacheUpdated } from '../slices/cache';
-import { subscribe } from '../thunks/cache';
+import { fetchCache, subscribe } from '../thunks/cache';
 import { fetchMetafile } from '../thunks/metafiles';
 import cardSelectors from '../selectors/cards';
 import metafileSelectors from '../selectors/metafiles';
@@ -21,7 +21,6 @@ export const FSCache = createContext({});
 
 export const FSCacheProvider = ({ children }: { children: ReactNode }) => {
     const cacheIds = useAppSelector(state => cacheSelectors.selectIds(state));
-    const cache = useAppSelector(state => cacheSelectors.selectEntities(state));
     const cards = useAppSelector(state => cardSelectors.selectAll(state));
     const metafiles = useAppSelector(state => metafileSelectors.selectEntities(state));
     const [watchers, watcherActions] = useMap<PathLike, FSWatcher>([]); // filepath to file watcher
@@ -70,7 +69,7 @@ export const FSCacheProvider = ({ children }: { children: ReactNode }) => {
                 break;
             }
             case 'change': {
-                const existing = cache[filename.toString()];
+                const existing = await dispatch(fetchCache(filename.toString())).unwrap();
                 if (existing) dispatch(cacheUpdated({
                     ...existing,
                     content: await readFileAsync(filename, { encoding: 'utf-8' })

--- a/src/store/thunks/cache.ts
+++ b/src/store/thunks/cache.ts
@@ -5,6 +5,13 @@ import cacheSelectors from '../selectors/cache';
 import { Cache, cacheRemoved, cacheUpdated } from '../slices/cache';
 import { UUID } from '../types';
 
+export const fetchCache = createAppAsyncThunk<Cache | undefined, PathLike>(
+    'cache/fetch',
+    async (path, thunkAPI) => {
+        return cacheSelectors.selectById(thunkAPI.getState(), path.toString());
+    }
+);
+
 export const subscribe = createAppAsyncThunk<Cache, { path: PathLike, card: UUID }>(
     'cache/subscribe',
     async ({ path, card }, thunkAPI) => {


### PR DESCRIPTION
The `FSCache` update event handler relies on [`useAppSelector(state => cacheSelectors.selectEntities(state))`](https://github.com/EPICLab/synectic/blob/21cda19298653b3f6953626260a49cb2cba03cb8/src/store/cache/FSCache.tsx#L24) for locating the existing `Cache` entry in order to pass it to the [`updateCache`](https://github.com/EPICLab/synectic/blob/21cda19298653b3f6953626260a49cb2cba03cb8/src/store/slices/cache.ts#L27) reducer (along with updated file content). However, this selector relies on [`shallowEqual`](https://github.com/reduxjs/reselect/blob/f2b08159b15230f50b8a988d9dafef5cc0b1f746/README.md#q-why-isnt-my-selector-recomputing-when-the-input-state-changes) comparisons of entities for determining when the selected value (in this case, the lookup table for `Cache` values) has changed and requires updating. This results in stale state information (especially the nested `reserved` table) being returned.

To prevent stale state information from being used in calls to [`updateCache`](https://github.com/EPICLab/synectic/blob/21cda19298653b3f6953626260a49cb2cba03cb8/src/store/slices/cache.ts#L27), this PR adds a new [`fetchCache` async thunk](https://github.com/EPICLab/synectic/blob/30bbe20a0f08ca940d34b094e73c439156c4efd5/src/store/thunks/cache.ts#L8-L13) so that Redux store state is only accessed upon dispatch and we can guarantee that the latest cache state is used in any subsequent updates.

This PR resolves #1057.

### **Changes**:

This PR makes the following changes:
* Add [`cache/fetch`](https://github.com/EPICLab/synectic/blob/30bbe20a0f08ca940d34b094e73c439156c4efd5/src/store/thunks/cache.ts#L8-L13) async thunk for resolving [`Cache`](https://github.com/EPICLab/synectic/blob/30bbe20a0f08ca940d34b094e73c439156c4efd5/src/store/slices/cache.ts#L6-L14) store entries based on filepath
* Use [`cache/fetch`](https://github.com/EPICLab/synectic/blob/30bbe20a0f08ca940d34b094e73c439156c4efd5/src/store/thunks/cache.ts#L8-L13) async thunk for `updateCache` calls in [`FSCache` update event handler
](https://github.com/EPICLab/synectic/blob/30bbe20a0f08ca940d34b094e73c439156c4efd5/src/store/cache/FSCache.tsx#L71-L78)
