### PR TITLE
Prune stale linked worktrees in `buildRepo` to prevent `ENOENT` errors when loading branch root directories

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -265,6 +265,7 @@ img.diff_icon {
 
 .card-front .list-component {
   height: 100%;
+  overflow-x: hidden;
 }
 
 .branch-ribbon-container {

--- a/src/store/thunks/repos.ts
+++ b/src/store/thunks/repos.ts
@@ -1,7 +1,7 @@
 import { PathLike } from 'fs-extra';
 import parsePath from 'parse-path';
 import { v4 } from 'uuid';
-import { extractFromURL, extractRepoName, getConfig, getWorktreePaths, GitConfig, listBranch } from '../../containers/git';
+import { extractFromURL, extractRepoName, getConfig, getWorktreePaths, GitConfig, listBranch, worktreePrune } from '../../containers/git';
 import { extractFilename } from '../../containers/io';
 import { ExactlyOne } from '../../containers/utils';
 import { createAppAsyncThunk } from '../hooks';
@@ -41,6 +41,7 @@ export const buildRepo = createAppAsyncThunk<Repository, PathLike>(
     async (filepath, thunkAPI) => {
         const { dir } = await getWorktreePaths(filepath);
         const { url, oauth } = await getRemoteConfig(dir);
+        if (dir) await worktreePrune({ dir: dir, verbose: true }); // Prune worktree information to remove stale linked branches
         const current = dir ? await listBranch({ dir: dir, showCurrent: true }) : [];
         const branches = dir ? await thunkAPI.dispatch(fetchBranches(dir)).unwrap() : { local: [], remote: [] };
         const { local, remote } = { local: branches.local.map(branch => branch.id), remote: branches.remote.map(branch => branch.id) };


### PR DESCRIPTION
Linked worktree branches that are deleted without using `git worktree remove` become _"prunable"_ and can lead to `ENOENT: no such file or directory` errors when loading and build `Repository` object models in Synectic. To mitigate these errors, this PR updates [`buildRepo`](https://github.com/EPICLab/synectic/blob/fe874ff6d7ee8695d3ae2f6745fe4c8b950ad99a/src/store/thunks/repos.ts#L39-L69) to automatically call [`worktreePrune`](https://github.com/EPICLab/synectic/blob/fe874ff6d7ee8695d3ae2f6745fe4c8b950ad99a/src/containers/git/git-worktree.ts#L156-L180) prior to fetching existing branches.

This PR resolves #1004.

### **Changes**:

This PR makes the following changes:
*  [`buildRepo`](https://github.com/EPICLab/synectic/blob/fe874ff6d7ee8695d3ae2f6745fe4c8b950ad99a/src/store/thunks/repos.ts#L39-L69) automatically calls [`worktreePrune`](https://github.com/EPICLab/synectic/blob/fe874ff6d7ee8695d3ae2f6745fe4c8b950ad99a/src/containers/git/git-worktree.ts#L156-L180) prior to fetching existing branches
* Prevent horizontal scrollbars from appearing for all components that match the `.card-front .list-component` CSS selector
