### PR TITLE
Store MD5 checksum values for `Cache` file content

### DIFF
--- a/src/components/Button/Save.tsx
+++ b/src/components/Button/Save.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
+import { IconButton, Tooltip } from '@material-ui/core';
 import { Save } from '@material-ui/icons';
+import { createHash } from 'crypto';
+import React from 'react';
 import { fileSaveDialog } from '../../containers/dialogs';
 import { writeFileAsync } from '../../containers/io';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { addItemInArray, removeItemInArray } from '../../store/immutables';
+import cachedSelectors from '../../store/selectors/cache';
 import cardSelectors from '../../store/selectors/cards';
 import metafileSelectors from '../../store/selectors/metafiles';
 import { cardUpdated } from '../../store/slices/cards';
 import { isFileMetafile, isVirtualMetafile, metafileUpdated } from '../../store/slices/metafiles';
-import { Mode, useIconButtonStyle } from './useStyledIconButton';
-import { IconButton, Tooltip } from '@material-ui/core';
-import { UUID } from '../../store/types';
 import { updateVersionedMetafile } from '../../store/thunks/metafiles';
-import cachedSelectors from '../../store/selectors/cache';
+import { UUID } from '../../store/types';
+import { Mode, useIconButtonStyle } from './useStyledIconButton';
 
 /**
  * Button for saving the content of modified metafiles to their associated files. This button tracks the state of metafiles associated
@@ -30,7 +31,7 @@ const SaveButton = ({ cardIds, enabled = true, mode = 'light' }: { cardIds: UUID
     const cards = useAppSelector(state => cardSelectors.selectByIds(state, cardIds));
     const metafiles = useAppSelector(state => metafileSelectors.selectByIds(state, cards.map(c => c.metafile)));
     const cache = useAppSelector(state => cachedSelectors.selectEntities(state));
-    const modified = metafiles.filter(m => (isFileMetafile(m) && m.content !== cache[m.path.toString()]?.content) || (isVirtualMetafile(m) && m.content && m.content.length > 0));
+    const modified = metafiles.filter(m => (isFileMetafile(m) && createHash('md5').update(m.content).digest('hex') !== cache[m.path.toString()]?.content) || (isVirtualMetafile(m) && m.content && m.content.length > 0));
     const dispatch = useAppDispatch();
     const classes = useIconButtonStyle({ mode: mode });
 

--- a/src/components/Button/Undo.tsx
+++ b/src/components/Button/Undo.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import { IconButton, Tooltip } from '@material-ui/core';
 import { Undo } from '@material-ui/icons';
+import { createHash } from 'crypto';
+import React from 'react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { addItemInArray, removeItemInArray } from '../../store/immutables';
+import cachedSelectors from '../../store/selectors/cache';
 import cardSelectors from '../../store/selectors/cards';
 import metafileSelectors from '../../store/selectors/metafiles';
 import { cardUpdated } from '../../store/slices/cards';
 import { isFileMetafile } from '../../store/slices/metafiles';
-import { Mode, useIconButtonStyle } from './useStyledIconButton';
-import { IconButton, Tooltip } from '@material-ui/core';
+import { updateFilebasedMetafile, updateVersionedMetafile } from '../../store/thunks/metafiles';
 import { UUID } from '../../store/types';
-import cachedSelectors from '../../store/selectors/cache';
-import { updateVersionedMetafile, updateFilebasedMetafile } from '../../store/thunks/metafiles';
+import { Mode, useIconButtonStyle } from './useStyledIconButton';
 
 /**
  * Button for undoing changes back to the most recent version according to the filesystem for file-based cards. This button tracks the 
@@ -28,7 +29,7 @@ const UndoButton = ({ cardIds, enabled = true, mode = 'light' }: { cardIds: UUID
     const cards = useAppSelector(state => cardSelectors.selectByIds(state, cardIds));
     const metafiles = useAppSelector(state => metafileSelectors.selectByIds(state, cards.map(c => c.metafile)));
     const cache = useAppSelector(state => cachedSelectors.selectEntities(state));
-    const modified = metafiles.filter(m => m.path && m.content !== cache[m.path.toString()]?.content);
+    const modified = metafiles.filter(m => isFileMetafile(m) && createHash('md5').update(m.content).digest('hex') !== cache[m.path.toString()]?.content);
     const dispatch = useAppDispatch();
     const classes = useIconButtonStyle({ mode: mode });
 

--- a/src/store/slices/cache.ts
+++ b/src/store/slices/cache.ts
@@ -9,7 +9,7 @@ export type Cache = {
     readonly path: string;
     /** The list of Card UUIDs with an interest in this cache object. */
     readonly reserved: UUID[];
-    /** The cached content associated with the underlying object content in the filesystem. */
+    /** The MD5 checksum value of cached content associated with the underlying object in the filesystem. */
     readonly content: string;
 }
 

--- a/src/store/thunks/cache.spec.ts
+++ b/src/store/thunks/cache.spec.ts
@@ -6,6 +6,7 @@ import { Cache, cacheAdded } from '../slices/cache';
 import { FileMetafile, metafileAdded } from '../slices/metafiles';
 import { DateTime } from 'luxon';
 import { Card, cardAdded } from '../slices/cards';
+import { createHash } from 'crypto';
 
 const card: Card = {
     id: 'f6b3f2a3-9145-4b59-a4a1-bf414214f30b',
@@ -65,7 +66,7 @@ describe('thunks/cards', () => {
         expect(cache).toStrictEqual(expect.objectContaining({
             path: metafile.path.toString(),
             reserved: expect.arrayContaining([card.id]),
-            content: metafile.content
+            content: createHash('md5').update(metafile.content).digest('hex')
         }));
     });
 
@@ -73,7 +74,7 @@ describe('thunks/cards', () => {
         const cache: Cache = {
             path: metafile.path.toString(),
             reserved: [card.id],
-            content: metafile.content
+            content: createHash('md5').update(metafile.content).digest('hex')
         }
         store.dispatch(cacheAdded(cache));
         const updated = await store.dispatch(subscribe({ path: 'foo/example.ts', card: '3f9ea183-d648-4a30-ad76-bcbec3e60b55' })).unwrap();

--- a/src/store/thunks/cache.ts
+++ b/src/store/thunks/cache.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { PathLike } from 'fs-extra';
 import { readFileAsync } from '../../containers/io';
 import { createAppAsyncThunk } from '../hooks';
@@ -21,7 +22,7 @@ export const subscribe = createAppAsyncThunk<Cache, { path: PathLike, card: UUID
         return thunkAPI.dispatch(cacheUpdated({
             path: path.toString(),
             reserved: reserved,
-            content: await readFileAsync(path, { encoding: 'utf-8' })
+            content: createHash('md5').update(await readFileAsync(path, { encoding: 'utf-8' })).digest('hex')
         })).payload;
     }
 );

--- a/src/store/thunks/metafiles.ts
+++ b/src/store/thunks/metafiles.ts
@@ -196,9 +196,8 @@ export const revertChanges = createAppAsyncThunk<void, VersionedMetafile>(
 
         if (metafile.status !== 'unmodified' && branch) {
             await checkoutPathspec({ dir: branch.root, pathspec: metafile.path.toString(), ours: true });
-            let updated = await thunkAPI.dispatch(updateFilebasedMetafile(metafile)).unwrap();
-            updated = await thunkAPI.dispatch(updateVersionedMetafile(updated)).unwrap();
-            console.log(updated);
+            const updated = await thunkAPI.dispatch(updateFilebasedMetafile(metafile)).unwrap();
+            await thunkAPI.dispatch(updateVersionedMetafile(updated)).unwrap();
         }
     }
 )


### PR DESCRIPTION
The [`Cache`](https://github.com/EPICLab/synectic/blob/ba346872565ec856da5d21f8b62cf49f78d4bcd6/src/store/slices/cache.ts#L6-L14) state objects maintain a copy of file contents for any tracked file in Synectic. These cached copies require reading and updating based on the filesystem. However, for very large files this can result in `SerializableStateInvariantMiddleware` warnings for excessive processing times (see #1082).

This PR improves upon this by only storing MD5 checksum values based on the file contents, which greatly reduces the size of stored content information in the Redux store.
### **Changes**:

This PR makes the following changes:
* Store checksum values based on `md5` hash of file contents in [`FSCache`](https://github.com/EPICLab/synectic/blob/ba346872565ec856da5d21f8b62cf49f78d4bcd6/src/store/cache/FSCache.tsx)
* Check for updates to/from [`FSCache`](https://github.com/EPICLab/synectic/blob/ba346872565ec856da5d21f8b62cf49f78d4bcd6/src/store/cache/FSCache.tsx) using `md5` checksum values

