### PR TITLE
Replace `uuid` package with built-in `Crypto` library for generating UUIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/redux-mock-store": "^1.0.3",
     "@types/semver": "^7.3.13",
     "@types/sha1": "^1.1.3",
-    "@types/uuid": "^9.0.0",
     "@types/valid-url": "^1.0.3",
     "@types/validator": "^13.7.10",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
@@ -138,7 +137,6 @@
     "redux-persist": "^6.0.0",
     "reselect": "^4.1.7",
     "semver": "^7.3.8",
-    "sha1": "^1.1.1",
-    "uuid": "^9.0.0"
+    "sha1": "^1.1.1"
   }
 }

--- a/src/components/Branches/BranchItem.tsx
+++ b/src/components/Branches/BranchItem.tsx
@@ -1,7 +1,7 @@
 import { DeleteForever as Delete } from '@material-ui/icons';
 import React from 'react';
 import { ConnectableElement, DropTargetMonitor, useDrag, useDrop } from 'react-dnd';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { useBranchMotif } from '../../containers/hooks/useMotif';
 import { removeNullableProperties } from '../../containers/utils';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
@@ -15,96 +15,124 @@ import { GitBranchIcon } from '../GitIcons';
 import { StyledTreeItem } from '../StyledTreeComponent';
 
 export type DragObject = {
-    id: string,
-    type: string
-}
+  id: string;
+  type: string;
+};
 
 type BranchItemProps = {
-    repoId: UUID;
-    branchId: UUID;
-    deletable?: boolean;
-    highlight?: boolean;
-    onClickHandler?: React.MouseEventHandler<HTMLLIElement> | undefined;
-}
+  repoId: UUID;
+  branchId: UUID;
+  deletable?: boolean;
+  highlight?: boolean;
+  onClickHandler?: React.MouseEventHandler<HTMLLIElement> | undefined;
+};
 
-const BranchItem = ({ repoId, branchId, deletable = false, highlight = false, onClickHandler = undefined }: BranchItemProps) => {
-    const branches = useAppSelector(state => branchSelectors.selectEntities(state));
-    const branch = useAppSelector(state => branchSelectors.selectById(state, branchId));
-    const repo = useAppSelector(state => repoSelectors.selectById(state, repoId));
-    const motif = useBranchMotif(branch);
-    const dispatch = useAppDispatch();
+const BranchItem = ({
+  repoId,
+  branchId,
+  deletable = false,
+  highlight = false,
+  onClickHandler = undefined
+}: BranchItemProps) => {
+  const branches = useAppSelector(state => branchSelectors.selectEntities(state));
+  const branch = useAppSelector(state => branchSelectors.selectById(state, branchId));
+  const repo = useAppSelector(state => repoSelectors.selectById(state, repoId));
+  const motif = useBranchMotif(branch);
+  const dispatch = useAppDispatch();
 
-    // Enable BranchItem as a drop source (i.e. allowing this component to be draggable)
-    const [{ isDragging }, drag] = useDrag({
-        type: DnDItemType.BRANCH,
-        item: () => ({ id: branchId, type: DnDItemType.CARD }),
-        collect: monitor => ({
-            isDragging: !!monitor.isDragging()
+  // Enable BranchItem as a drop source (i.e. allowing this component to be draggable)
+  const [{ isDragging }, drag] = useDrag(
+    {
+      type: DnDItemType.BRANCH,
+      item: () => ({ id: branchId, type: DnDItemType.CARD }),
+      collect: monitor => ({
+        isDragging: !!monitor.isDragging()
+      })
+    },
+    [branchId]
+  );
+
+  // Enable BranchItem as a drop target (i.e. allow other elements to be dropped on this component)
+  const [{ isOver }, drop] = useDrop(
+    {
+      accept: [DnDItemType.BRANCH],
+      canDrop: (_item, monitor: DropTargetMonitor<DragObject, void>) => {
+        const dropTarget = branch;
+        const dropSource = branches[monitor.getItem().id];
+        // restrict dropped items from accepting a self-referencing drop (i.e. dropping a card on itself)
+        const nonSelf = dropSource ? dropTarget?.id !== dropSource.id : false;
+        const sameRepo =
+          dropSource && repo
+            ? repo.local.includes(dropSource.id) || repo.remote.includes(dropSource.id)
+            : false;
+        return nonSelf && sameRepo;
+      },
+      drop: (_item, monitor: DropTargetMonitor<DragObject, void>) => {
+        const dropTarget = branch;
+        const dropSource = branches[monitor.getItem().id];
+        const delta = monitor.getDifferenceFromInitialOffset();
+        if (!delta) return; // no dragging is occurring, perhaps a draggable element was picked up and dropped without dragging
+        if (dropSource && dropTarget)
+          dispatch(
+            modalAdded({
+              id: randomUUID(),
+              type: 'MergeSelector',
+              options: { repo: repoId, base: dropTarget.id, compare: dropSource.id }
+            })
+          );
+      },
+      collect: monitor => ({
+        isOver: !!monitor.isOver() // return isOver prop to highlight drop sources that accept hovered item
+      })
+    },
+    [branches]
+  );
+
+  const dragAndDrop = (elementOrNode: ConnectableElement) => {
+    drag(elementOrNode);
+    drop(elementOrNode);
+  };
+
+  const handleLabelInfoClick = async (event: React.MouseEvent) => {
+    event.stopPropagation(); // prevent propogating the click event to the StyleTreeItem onClick method
+    if (branch && repo) {
+      const success = await dispatch(removeBranch({ repoId: repo.id, branch: branch })).unwrap();
+      dispatch(
+        modalAdded({
+          id: randomUUID(),
+          type: 'Notification',
+          options: {
+            message: `Branch '${branch.ref}' ${success ? 'successfully' : 'cannot be'} deleted`
+          }
         })
-    }, [branchId]);
-
-    // Enable BranchItem as a drop target (i.e. allow other elements to be dropped on this component)
-    const [{ isOver }, drop] = useDrop({
-        accept: [DnDItemType.BRANCH],
-        canDrop: (_item, monitor: DropTargetMonitor<DragObject, void>) => {
-            const dropTarget = branch;
-            const dropSource = branches[monitor.getItem().id];
-            // restrict dropped items from accepting a self-referencing drop (i.e. dropping a card on itself)
-            const nonSelf = dropSource ? (dropTarget?.id !== dropSource.id) : false;
-            const sameRepo = (dropSource && repo) ? repo.local.includes(dropSource.id) || repo.remote.includes(dropSource.id) : false;
-            return nonSelf && sameRepo;
-        },
-        drop: (_item, monitor: DropTargetMonitor<DragObject, void>) => {
-            const dropTarget = branch;
-            const dropSource = branches[monitor.getItem().id];
-            const delta = monitor.getDifferenceFromInitialOffset();
-            if (!delta)
-                return; // no dragging is occurring, perhaps a draggable element was picked up and dropped without dragging
-            if (dropSource && dropTarget)
-                dispatch(modalAdded({ id: v4(), type: 'MergeSelector', options: { repo: repoId, base: dropTarget.id, compare: dropSource.id } }));
-        },
-        collect: monitor => ({
-            isOver: !!monitor.isOver() // return isOver prop to highlight drop sources that accept hovered item
-        })
-    }, [branches]);
-
-    const dragAndDrop = (elementOrNode: ConnectableElement) => {
-        drag(elementOrNode);
-        drop(elementOrNode);
-    };
-
-    const handleLabelInfoClick = async (event: React.MouseEvent) => {
-        event.stopPropagation(); // prevent propogating the click event to the StyleTreeItem onClick method
-        if (branch && repo) {
-            const success = await dispatch(removeBranch({ repoId: repo.id, branch: branch })).unwrap();
-            dispatch(modalAdded({
-                id: v4(), type: 'Notification',
-                options: { 'message': `Branch '${branch.ref}' ${success ? 'successfully' : 'cannot be'} deleted` }
-            }));
-        }
+      );
     }
+  };
 
-    const optionals = removeNullableProperties({
-        color: motif?.color,
-        labelInfo: deletable ? Delete : undefined,
-        labelInfoClickHandler: deletable ? handleLabelInfoClick : undefined
-    });
+  const optionals = removeNullableProperties({
+    color: motif?.color,
+    labelInfo: deletable ? Delete : undefined,
+    labelInfoClickHandler: deletable ? handleLabelInfoClick : undefined
+  });
 
-    return (
-        <div ref={dragAndDrop}>
-            <StyledTreeItem
-                className={`${isOver ? 'drop-source' : ''}`}
-                style={{ backgroundColor: highlight ? 'rgba(255, 192, 203, 0.5)' : undefined, opacity: isDragging ? 0 : 1 }}
-                key={`${repoId}-${branchId}`}
-                nodeId={`${repoId}-${branchId}`}
-                labelText={`${branch?.scope}/${branch?.ref}`}
-                {...optionals}
-                labelIcon={GitBranchIcon}
-                enableHover={true}
-                onClick={onClickHandler}
-            />
-        </div>
-    )
-}
+  return (
+    <div ref={dragAndDrop}>
+      <StyledTreeItem
+        className={`${isOver ? 'drop-source' : ''}`}
+        style={{
+          backgroundColor: highlight ? 'rgba(255, 192, 203, 0.5)' : undefined,
+          opacity: isDragging ? 0 : 1
+        }}
+        key={`${repoId}-${branchId}`}
+        nodeId={`${repoId}-${branchId}`}
+        labelText={`${branch?.scope}/${branch?.ref}`}
+        {...optionals}
+        labelIcon={GitBranchIcon}
+        enableHover={true}
+        onClick={onClickHandler}
+      />
+    </div>
+  );
+};
 
 export default BranchItem;

--- a/src/components/Branches/BranchList.tsx
+++ b/src/components/Branches/BranchList.tsx
@@ -1,6 +1,6 @@
 import { TreeView } from '@material-ui/lab';
 import React from 'react';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import branchSelectors from '../../store/selectors/branches';
 import cardSelectors from '../../store/selectors/cards';
@@ -14,61 +14,80 @@ import BranchItem from './BranchItem';
 
 /**
  * React Component to display a list of branches from the repository associated with a particular card. The list
- * includes both local and remote branches, and allows for checking out any branch at any point (without concern 
- * for whether there are changes on a particular branch). Checkouts will only affect the contents of the indicated 
+ * includes both local and remote branches, and allows for checking out any branch at any point (without concern
+ * for whether there are changes on a particular branch). Checkouts will only affect the contents of the indicated
  * card.
- * 
+ *
  * @param props Prop object for branches on a specific repository.
  * @param props.cardId - The UUID for the parent Card component displaying this component.
  * @param props.repoId - The UUID of the repository used to find and display branches.
  * @returns {React.Component} A React function component.
  */
-const BranchList = ({ cardId, repoId }: { cardId: UUID, repoId: UUID }) => {
-    const card = useAppSelector(state => cardSelectors.selectById(state, cardId));
-    const metafile = useAppSelector(state => metafileSelectors.selectById(state, card?.metafile ?? ''));
-    const repo = useAppSelector(state => repoSelectors.selectById(state, repoId));
-    const repoBranches = useAppSelector(state => branchSelectors.selectByRepo(state, repo?.id ?? '', true));
-    const branches = repoBranches.filter(branch => branch.ref !== 'HEAD').sort((a, b) => a.ref.localeCompare(b.ref));
-    const dispatch = useAppDispatch();
+const BranchList = ({ cardId, repoId }: { cardId: UUID; repoId: UUID }) => {
+  const card = useAppSelector(state => cardSelectors.selectById(state, cardId));
+  const metafile = useAppSelector(state =>
+    metafileSelectors.selectById(state, card?.metafile ?? '')
+  );
+  const repo = useAppSelector(state => repoSelectors.selectById(state, repoId));
+  const repoBranches = useAppSelector(state =>
+    branchSelectors.selectByRepo(state, repo?.id ?? '', true)
+  );
+  const branches = repoBranches
+    .filter(branch => branch.ref !== 'HEAD')
+    .sort((a, b) => a.ref.localeCompare(b.ref));
+  const dispatch = useAppDispatch();
 
-    const checkout = async (branchId: UUID, branchRef: string) => {
-        if (metafile?.branch === branchId) {
-            dispatch(modalAdded({
-                id: v4(), type: 'Notification',
-                options: { 'message': `Card already set to branch '${branchRef}'` }
-            }));
-        }
-        console.log(`checkout: ${branchRef}`);
-        if (card && metafile && repo) {
-            try {
-                const updated = await dispatch(switchBranch({ metafileId: metafile.id, cardId: card.id, ref: branchRef, root: repo.root })).unwrap();
-                if (updated) dispatch(cardUpdated({
-                    ...card,
-                    name: updated.name,
-                    modified: updated.modified,
-                    metafile: updated.id
-                }));
-            } catch (error) {
-                console.error(`Checkout failed: `, error);
-            }
-        }
-    };
+  const checkout = async (branchId: UUID, branchRef: string) => {
+    if (metafile?.branch === branchId) {
+      dispatch(
+        modalAdded({
+          id: randomUUID(),
+          type: 'Notification',
+          options: { message: `Card already set to branch '${branchRef}'` }
+        })
+      );
+    }
+    console.log(`checkout: ${branchRef}`);
+    if (card && metafile && repo) {
+      try {
+        const updated = await dispatch(
+          switchBranch({
+            metafileId: metafile.id,
+            cardId: card.id,
+            ref: branchRef,
+            root: repo.root
+          })
+        ).unwrap();
+        if (updated)
+          dispatch(
+            cardUpdated({
+              ...card,
+              name: updated.name,
+              modified: updated.modified,
+              metafile: updated.id
+            })
+          );
+      } catch (error) {
+        console.error(`Checkout failed: `, error);
+      }
+    }
+  };
 
-    return (
-        <div className='list-component'>
-            <TreeView expanded={repo ? [repo.id] : []}>
-                {branches.map(branch =>
-                    <BranchItem
-                        key={branch.id}
-                        repoId={repoId}
-                        branchId={branch.id}
-                        highlight={metafile?.branch === branch.id}
-                        onClickHandler={() => checkout(branch.id, branch.ref)}
-                    />
-                )}
-            </TreeView>
-        </div>
-    );
-}
+  return (
+    <div className="list-component">
+      <TreeView expanded={repo ? [repo.id] : []}>
+        {branches.map(branch => (
+          <BranchItem
+            key={branch.id}
+            repoId={repoId}
+            branchId={branch.id}
+            highlight={metafile?.branch === branch.id}
+            onClickHandler={() => checkout(branch.id, branch.ref)}
+          />
+        ))}
+      </TreeView>
+    </div>
+  );
+};
 
 export default BranchList;

--- a/src/components/Button/Commit.tsx
+++ b/src/components/Button/Commit.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo } from 'react';
-import { v4 } from 'uuid';
+import React from 'react';
 import { IconButton, Tooltip } from '@material-ui/core';
 import { Done } from '@material-ui/icons';
 import cardSelectors from '../../store/selectors/cards';
@@ -12,70 +11,89 @@ import { Modal, modalAdded } from '../../store/slices/modals';
 import { UUID } from '../../store/types';
 import { isVersionedMetafile, Metafile } from '../../store/slices/metafiles';
 import { isStaged } from '../../containers/utils';
+import { randomUUID } from 'crypto';
 
 /**
- * Button for initiating commits to a specific branch and repository. This button tracks the status of metafiles associated 
- * with the list of cards supplied via props. The button is only enabled when at least one associated metafile has a VCS 
+ * Button for initiating commits to a specific branch and repository. This button tracks the status of metafiles associated
+ * with the list of cards supplied via props. The button is only enabled when at least one associated metafile has a VCS
  * status of `added`, `modified`, or `deleted`. Clicking on the button will trigger a `CommitDialog` modal to be loaded.
- * 
+ *
  * @param props - Prop object for cards on a specific branch and repository.
  * @param props.cardIds - List of Card UUIDs that should be tracked by this button.
  * @param props.enabled - Optional flag for including logic that hides this button if false; defaults to true.
  * @param props.mode - Optional mode for switching between light and dark themes.
  * @returns {React.Component} A React function component.
  */
-const CommitButton = ({ cardIds, enabled = true, mode = 'light' }: { cardIds: UUID[], enabled?: boolean, mode?: Mode }) => {
-    const cards = useAppSelector(state => cardSelectors.selectByIds(state, cardIds));
-    const metafiles = useAppSelector(state => metafileSelectors.selectByIds(state, cards.map(c => c.metafile)));
-    // const selectByIds = useMemo(metafileSelectors.makeSelectByIds, []); // create a memoized selector for each component instance, on mount
-    // const metafiles = useAppSelector(state => selectByIds(state, cards.map(c => c.metafile)));
-    const staged = metafiles.filter(m => isVersionedMetafile(m) && isStaged(m.status));
-    const classes = useIconButtonStyle({ mode: mode });
-    const dispatch = useAppDispatch();
+const CommitButton = ({
+  cardIds,
+  enabled = true,
+  mode = 'light'
+}: {
+  cardIds: UUID[];
+  enabled?: boolean;
+  mode?: Mode;
+}) => {
+  const cards = useAppSelector(state => cardSelectors.selectByIds(state, cardIds));
+  const metafiles = useAppSelector(state =>
+    metafileSelectors.selectByIds(
+      state,
+      cards.map(c => c.metafile)
+    )
+  );
+  // const selectByIds = useMemo(metafileSelectors.makeSelectByIds, []); // create a memoized selector for each component instance, on mount
+  // const metafiles = useAppSelector(state => selectByIds(state, cards.map(c => c.metafile)));
+  const staged = metafiles.filter(m => isVersionedMetafile(m) && isStaged(m.status));
+  const classes = useIconButtonStyle({ mode: mode });
+  const dispatch = useAppDispatch();
 
-    const hasStaged = staged.length > 0;
-    const isCaptured = cards[0]?.captured !== undefined;
+  const hasStaged = staged.length > 0;
+  const isCaptured = cards[0]?.captured !== undefined;
 
-    const commit = async (event: React.MouseEvent) => {
-        event.stopPropagation(); // prevent propogating the click event to underlying components that might have click event handlers
-        const firstMetafile = staged[0];
-        if (firstMetafile && firstMetafile.repo && firstMetafile.branch) {
-            const commitDialogModal: Modal = {
-                id: v4(),
-                type: 'CommitDialog',
-                options: {
-                    'repo': firstMetafile.repo,
-                    'branch': firstMetafile.branch
-                }
-            };
-            dispatch(modalAdded(commitDialogModal));
+  const commit = async (event: React.MouseEvent) => {
+    event.stopPropagation(); // prevent propogating the click event to underlying components that might have click event handlers
+    const firstMetafile = staged[0];
+    if (firstMetafile && firstMetafile.repo && firstMetafile.branch) {
+      const commitDialogModal: Modal = {
+        id: randomUUID(),
+        type: 'CommitDialog',
+        options: {
+          repo: firstMetafile.repo,
+          branch: firstMetafile.branch
         }
-    };
-
-    const onHover = (target: Metafile[]) => {
-        if (cards.length > 1) {
-            cards.filter(c => target.find(m => c.metafile === m.id) ? true : false)
-                .map(c => dispatch(cardUpdated({ ...c, classes: addItemInArray(c.classes, 'selected-card') })));
-        }
+      };
+      dispatch(modalAdded(commitDialogModal));
     }
+  };
 
-    const offHover = () => {
-        cards.map(c => dispatch(cardUpdated({ ...c, classes: removeItemInArray(c.classes, 'selected-card') })));
+  const onHover = (target: Metafile[]) => {
+    if (cards.length > 1) {
+      cards
+        .filter(c => (target.find(m => c.metafile === m.id) ? true : false))
+        .map(c =>
+          dispatch(cardUpdated({ ...c, classes: addItemInArray(c.classes, 'selected-card') }))
+        );
     }
+  };
 
-    return (enabled && hasStaged && !isCaptured) ? (
-        <Tooltip title='Commit'>
-            <IconButton
-                className={classes.root}
-                aria-label='commit'
-                onClick={commit}
-                onMouseEnter={() => onHover(staged)}
-                onMouseLeave={offHover}
-            >
-                <Done />
-            </IconButton>
-        </Tooltip>
-    ) : null;
-}
+  const offHover = () => {
+    cards.map(c =>
+      dispatch(cardUpdated({ ...c, classes: removeItemInArray(c.classes, 'selected-card') }))
+    );
+  };
+
+  return enabled && hasStaged && !isCaptured ? (
+    <Tooltip title="Commit">
+      <IconButton
+        className={classes.root}
+        aria-label="commit"
+        onClick={commit}
+        onMouseEnter={() => onHover(staged)}
+        onMouseLeave={offHover}
+      >
+        <Done />
+      </IconButton>
+    </Tooltip>
+  ) : null;
+};
 
 export default CommitButton;

--- a/src/components/GitGraph/GitGraphSelect.tsx
+++ b/src/components/GitGraph/GitGraphSelect.tsx
@@ -1,9 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { shallowEqual } from 'react-redux';
-import { createStyles, FormControl, makeStyles, MenuItem, Select, Theme, withStyles } from '@material-ui/core';
+import {
+  createStyles,
+  FormControl,
+  makeStyles,
+  MenuItem,
+  Select,
+  Theme,
+  withStyles
+} from '@material-ui/core';
 import InputBase from '@material-ui/core/InputBase';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import repoSelectors from '../../store/selectors/repos';
 import modalSelectors from '../../store/selectors/modals';
 import { Modal, modalAdded, modalRemoved } from '../../store/slices/modals';
@@ -21,36 +29,41 @@ const StyledInput = withStyles((theme: Theme) =>
       '&:focus': {
         borderRadius: 4,
         borderColor: '#80bdff',
-        boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
-      },
-    },
-  }),
+        boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)'
+      }
+    }
+  })
 )(InputBase);
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
-      margin: theme.spacing(1),
+      margin: theme.spacing(1)
     },
     defaultItem: {
-      color: 'rgba(125,125,125,1)',
+      color: 'rgba(125,125,125,1)'
     }
-  }),
+  })
 );
 
 const GitGraphSelect = () => {
   const repos = useAppSelector(state => repoSelectors.selectAll(state));
   const [selected, setSelected] = useState('');
-  const graphs: Modal[] = useAppSelector(state => modalSelectors.selectByType(state, 'GitGraph'), shallowEqual);
+  const graphs: Modal[] = useAppSelector(
+    state => modalSelectors.selectByType(state, 'GitGraph'),
+    shallowEqual
+  );
   const dispatch = useAppDispatch();
   const styles = useStyles();
 
-  const handleChange = (event: React.ChangeEvent<{ value: string }>) => setSelected(event.target.value);
+  const handleChange = (event: React.ChangeEvent<{ value: string }>) =>
+    setSelected(event.target.value);
 
   useEffect(() => {
     if (graphs.length > 0) graphs.map(graph => dispatch(modalRemoved(graph.id)));
     const selectedRepo = repos.find(r => r.id === selected);
-    if (selectedRepo) dispatch(modalAdded({ id: v4(), type: 'GitGraph', target: selected }));
+    if (selectedRepo)
+      dispatch(modalAdded({ id: randomUUID(), type: 'GitGraph', target: selected }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repos, selected]);
 
@@ -58,25 +71,27 @@ const GitGraphSelect = () => {
     <div style={{ marginLeft: 'auto' }}>
       <FormControl className={styles.margin}>
         <Select
-          labelId='repo-select-label'
-          id='repo-select'
+          labelId="repo-select-label"
+          id="repo-select"
           value={repos.find(r => r.id === selected) ? selected : ''}
-          defaultValue=''
+          defaultValue=""
           displayEmpty
           disabled={repos.length === 0}
           onChange={handleChange}
           input={<StyledInput />}
         >
-          <MenuItem key='' value='' className={styles.defaultItem}>{selected ? 'Clear Map' : 'Repository Map'}</MenuItem>
-          {repos.map((repo) =>
+          <MenuItem key="" value="" className={styles.defaultItem}>
+            {selected ? 'Clear Map' : 'Repository Map'}
+          </MenuItem>
+          {repos.map(repo => (
             <MenuItem key={repo.id} value={repo.id}>
               {repo.name}
             </MenuItem>
-          )}
+          ))}
         </Select>
       </FormControl>
     </div>
   );
-}
+};
 
 export default GitGraphSelect;

--- a/src/components/GitGraph/GitNode.tsx
+++ b/src/components/GitGraph/GitNode.tsx
@@ -1,33 +1,34 @@
 import React, { useState } from 'react';
 import { clipboard } from 'electron';
 import { Handle, NodeProps, Position } from 'reactflow';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { ColorSet } from '../../containers/colors';
 import { removeNullableProperties } from '../../containers/utils';
 import { useAppDispatch } from '../../store/hooks';
 import { modalAdded } from '../../store/slices/modals';
 import OutlinedCard from './GitGraphTag';
 
-const customNodeStyles = (color: ColorSet, border: string, opacity?: string) => removeNullableProperties({
-  borderRadius: '50%',
-  borderStyle: border,
-  borderWidth: 'thin',
-  opacity: opacity,
-  background: color.primary,
-  color: color.secondary,
-  padding: 5,
-});
+const customNodeStyles = (color: ColorSet, border: string, opacity?: string) =>
+  removeNullableProperties({
+    borderRadius: '50%',
+    borderStyle: border,
+    borderWidth: 'thin',
+    opacity: opacity,
+    background: color.primary,
+    color: color.secondary,
+    padding: 5
+  });
 
 type GitNodeProps = NodeProps & {
   data: {
-    text: string,
-    tooltip: string,
-    color: ColorSet,
-    border: string,
-    opacity?: string,
-    branch?: string
-  }
-}
+    text: string;
+    tooltip: string;
+    color: ColorSet;
+    border: string;
+    opacity?: string;
+    branch?: string;
+  };
+};
 
 const GitNode = (props: GitNodeProps) => {
   const [isHovering, setIsHovering] = useState(false);
@@ -35,30 +36,39 @@ const GitNode = (props: GitNodeProps) => {
 
   const copyToClipboard = () => {
     clipboard.writeText(props.id);
-    dispatch(modalAdded({
-      id: v4(),
-      type: 'Notification',
-      options: {
-        'message': `'${props.id.replace(props.id.slice(7, -7), '...')}' copied to clipboard`
-      }
-    }));
-  }
+    dispatch(
+      modalAdded({
+        id: randomUUID(),
+        type: 'Notification',
+        options: {
+          message: `'${props.id.replace(props.id.slice(7, -7), '...')}' copied to clipboard`
+        }
+      })
+    );
+  };
 
   return (
     <>
-      {props.data.branch ? <OutlinedCard content={props.data.branch} placement='right' /> : null}
-      {isHovering ? <OutlinedCard content={`commit ${props.id}\nAuthor: ${props.data.author}\nMessage: ${props.data.message}`} placement='bottom' /> : null}
-      <div style={customNodeStyles(props.data.color, props.data.border, props.data.opacity)}
-        onMouseEnter={() => setIsHovering(true)} onMouseLeave={() => setIsHovering(false)}
+      {props.data.branch ? <OutlinedCard content={props.data.branch} placement="right" /> : null}
+      {isHovering ? (
+        <OutlinedCard
+          content={`commit ${props.id}\nAuthor: ${props.data.author}\nMessage: ${props.data.message}`}
+          placement="bottom"
+        />
+      ) : null}
+      <div
+        style={customNodeStyles(props.data.color, props.data.border, props.data.opacity)}
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
         onClick={copyToClipboard}
       >
-        <Handle type='target' position={Position.Top} style={{ visibility: 'hidden' }} />
+        <Handle type="target" position={Position.Top} style={{ visibility: 'hidden' }} />
         <div style={{ background: 'red' }}>{props.data.text}</div>
-        <Handle type='source' position={Position.Bottom} style={{ visibility: 'hidden' }} />
+        <Handle type="source" position={Position.Bottom} style={{ visibility: 'hidden' }} />
       </div>
     </>
-  )
-}
+  );
+};
 
 export const nodeTypes = {
   gitNode: GitNode

--- a/src/containers/git/git-ignore.ts
+++ b/src/containers/git/git-ignore.ts
@@ -9,24 +9,26 @@ import { extractFilename, readDirAsyncDepth, readFileAsync } from '../io';
  *
  * @param dir The relative or absolute directory path to search.
  * @param useGitRules Include ignore rules common to git projects (i.e. excluding `.git` and `node_modules` directories).
- * @returns {Promise<Ignore>} A Promise object containing a Ignore object that can be interacted with according to the 
+ * @returns {Promise<Ignore>} A Promise object containing a Ignore object that can be interacted with according to the
  * [`ignore`](https://github.com/kaelzhang/node-ignore) API documentation.
  */
 export const getIgnore = async (dir: PathLike, useGitRules = false): Promise<Ignore> => {
-    const ignoreFiles = (await readDirAsyncDepth(dir, 2)).filter(filename => extractFilename(filename) === '.gitignore');
-    const ignoreManager = ignore();
-    ignoreFiles.map(async ignoreFile => {
-        const content = await readFileAsync(ignoreFile, { encoding: 'utf-8' });
-        ignoreManager.add(content);
-    });
-    if (useGitRules) {
-        // this rule is standard for git-based projects
-        ignoreManager.add('.git');
-        // .gitignore files often incldue 'node_modules/' as a rule, but node-ignore requires the trailing '/' for directories and node 
-        // `path` mismatches that by returning only the directory name. See: https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames
-        ignoreManager.add('node_modules');
-        // A .DS_Store file is a Mac OS X folder information file that stores custom attributes of the containing folder.
-        ignoreManager.add('.DS_Store');
-    }
-    return ignoreManager;
-}
+  const ignoreFiles = (await readDirAsyncDepth(dir, 2)).filter(
+    filename => extractFilename(filename) === '.gitignore'
+  );
+  const ignoreManager = ignore();
+  ignoreFiles.map(async ignoreFile => {
+    const content = (await readFileAsync(ignoreFile, { encoding: 'utf-8' })).toString();
+    ignoreManager.add(content);
+  });
+  if (useGitRules) {
+    // this rule is standard for git-based projects
+    ignoreManager.add('.git');
+    // .gitignore files often incldue 'node_modules/' as a rule, but node-ignore requires the trailing '/' for directories and node
+    // `path` mismatches that by returning only the directory name. See: https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames
+    ignoreManager.add('node_modules');
+    // A .DS_Store file is a Mac OS X folder information file that stores custom attributes of the containing folder.
+    ignoreManager.add('.DS_Store');
+  }
+  return ignoreManager;
+};

--- a/src/containers/git/git-merge.ts
+++ b/src/containers/git/git-merge.ts
@@ -1,6 +1,11 @@
 import * as path from 'path';
 import { SHA1 } from '../../store/types';
-import { execute, getConflictingChunks, ProgressCallback, removeNullableProperties } from '../utils';
+import {
+  execute,
+  getConflictingChunks,
+  ProgressCallback,
+  removeNullableProperties
+} from '../utils';
 import { worktreeList } from './git-worktree';
 import { pathExists, PathLike } from 'fs-extra';
 import { getBranchRoot, getWorktreePaths } from './git-path';
@@ -15,12 +20,12 @@ import { revParse } from './git-rev-parse';
 export type Conflict = Pick<VersionedMetafile, 'path' | 'conflicts'>;
 
 export type MergeOutput = {
-    status: Status,
-    alreadyMerged: boolean,
-    fastForward: boolean,
-    mergeCommit?: SHA1,
-    output?: string,
-    conflicts?: PathLike[]
+  status: Status;
+  alreadyMerged: boolean;
+  fastForward: boolean;
+  mergeCommit?: SHA1;
+  output?: string;
+  conflicts?: PathLike[];
 };
 
 /**
@@ -30,7 +35,7 @@ export type MergeOutput = {
  *
  * @param obj - A destructured object for named parameters.
  * @param obj.dir - The worktree root directory.
- * @param obj.squash - Optional flag to produce the working tree and index state as if a real merge happened (except for the 
+ * @param obj.squash - Optional flag to produce the working tree and index state as if a real merge happened (except for the
  * merge information), but do not actually make a commit, move the HEAD, or record `@GIT_DIR/MERGE_HEAD` (to cause the next
  * `git commit` command to create a merge commit). This allows you to create a single commit on top of the current branch whose
  * effect is the same as merging another branch (or more in case of an octopus). Defaults to `false`.
@@ -46,105 +51,126 @@ export type MergeOutput = {
  * results of the merge.
  */
 export const mergeBranch = async ({
-    dir, squash = false, fastForwardOnly = false, verify = true, quiet = false, base, commitish, message, onProgress
+  dir,
+  squash = false,
+  fastForwardOnly = false,
+  verify = true,
+  quiet = false,
+  base,
+  commitish,
+  message,
+  onProgress
 }: {
-    dir: PathLike;
-    squash?: boolean;
-    fastForwardOnly?: boolean;
-    verify?: boolean;
-    quiet?: boolean;
-    base?: string;
-    commitish: string;
-    message?: string;
-    onProgress?: ProgressCallback
+  dir: PathLike;
+  squash?: boolean;
+  fastForwardOnly?: boolean;
+  verify?: boolean;
+  quiet?: boolean;
+  base?: string;
+  commitish: string;
+  message?: string;
+  onProgress?: ProgressCallback;
 }): Promise<MergeOutput> => {
-    const baseBranch = base ? (await worktreeList({ dir: dir })).find(w => w.ref === base) : undefined;
-    const root = baseBranch?.root ? baseBranch.root : dir;
+  const baseBranch = base
+    ? (await worktreeList({ dir: dir })).find(w => w.ref === base)
+    : undefined;
+  const root = baseBranch?.root ? baseBranch.root : dir;
 
-    if (!quiet && onProgress && baseBranch) {
-        const commits = (await revList({ dir: root, commitish: [baseBranch.ref, `^` + commitish] })).split(/\r?\n/);
-        await Promise.all(commits.map(async (commit, idx) =>
-            await onProgress({ phase: `Merging commit '${commit}' into '${baseBranch.ref}' branch`, loaded: idx, total: commits.length })
-        ));
-    }
-    const output = await execute(`git merge ${squash ? '--squash' : ''} ${quiet ? '--quiet' : ''} ${!verify ? '--no-verify' : ''} ` +
-        `${fastForwardOnly ? '--ff-only' : ''} ${commitish} ${message ? `-m ${message}` : ''}`, root.toString());
+  if (!quiet && onProgress && baseBranch) {
+    const commits = (
+      await revList({ dir: root, commitish: [baseBranch.ref, `^` + commitish] })
+    ).split(/\r?\n/);
+    await Promise.all(
+      commits.map(
+        async (commit, idx) =>
+          await onProgress({
+            phase: `Merging commit '${commit}' into '${baseBranch.ref}' branch`,
+            loaded: idx,
+            total: commits.length
+          })
+      )
+    );
+  }
+  const output = await execute(
+    `git merge ${squash ? '--squash' : ''} ${quiet ? '--quiet' : ''} ${
+      !verify ? '--no-verify' : ''
+    } ` + `${fastForwardOnly ? '--ff-only' : ''} ${commitish} ${message ? `-m ${message}` : ''}`,
+    root.toString()
+  );
 
-    if (!quiet && output.stderr.length > 0) {
-        if (onProgress) await onProgress({ phase: output.stderr, loaded: 1, total: 1 });
-        console.error(output.stderr);
-    }
-    if (!quiet && output.stdout.length > 0) {
-        if (onProgress) await onProgress({ phase: output.stdout, loaded: 1, total: 1 });
-        console.log(output.stdout);
-    }
+  if (!quiet && output.stderr.length > 0) {
+    if (onProgress) await onProgress({ phase: output.stderr, loaded: 1, total: 1 });
+    console.error(output.stderr);
+  }
+  if (!quiet && output.stdout.length > 0) {
+    if (onProgress) await onProgress({ phase: output.stdout, loaded: 1, total: 1 });
+    console.log(output.stdout);
+  }
 
-    return await processMergeOutput(output, root);
-}
+  return await processMergeOutput(output, root);
+};
 
 export const mergeInProgress = async ({
-    dir,
-    action
+  dir,
+  action
 }: {
-    dir: PathLike;
-    action: 'continue' | 'abort' | 'quit';
+  dir: PathLike;
+  action: 'continue' | 'abort' | 'quit';
 }) => {
-    const output = await execute(`git merge --${action}`, dir.toString());
-    // TODO: false should be returned when the output is `fatal: There is no merge in progress (MERGE_HEAD missing).`
-    // TODO: false should be returned when the output is `fatal: There is no merge to abort (MERGE_HEAD missing).`
-    // TODO: false should be returned when `quit` is used, but there is no MERGE_HEAD (although no output is shown typically).
-    if (output.stderr.length > 0) {
-        console.error(output.stderr);
-        return false;
-    }
-    if (output.stdout.length > 0) console.log(output.stdout);
-    return true;
-}
-
+  const output = await execute(`git merge --${action}`, dir.toString());
+  // TODO: false should be returned when the output is `fatal: There is no merge in progress (MERGE_HEAD missing).`
+  // TODO: false should be returned when the output is `fatal: There is no merge to abort (MERGE_HEAD missing).`
+  // TODO: false should be returned when `quit` is used, but there is no MERGE_HEAD (although no output is shown typically).
+  if (output.stderr.length > 0) {
+    console.error(output.stderr);
+    return false;
+  }
+  if (output.stdout.length > 0) console.log(output.stdout);
+  return true;
+};
 
 /**
  * Check for conflicting chunks within a specific directory or file.
- * 
+ *
  * @param filepath - The relative or absolute path to evaluate.
  * @returns {Promise<Conflict[]>} A Promise object containing an array of conflict information found in the specified
  * file or directory (the array does not include entries for non-conflicting files).
  */
 export const checkUnmergedPath = async (filepath: PathLike): Promise<Conflict[]> => {
-    const isDir = await isDirectory(filepath);
-    return isDir ? await checkUnmergedDirectory(filepath) : await checkUnmergedFile(filepath);
-}
-
+  const isDir = await isDirectory(filepath);
+  return isDir ? await checkUnmergedDirectory(filepath) : await checkUnmergedFile(filepath);
+};
 
 const checkUnmergedFile = async (filepath: PathLike): Promise<Conflict[]> => {
-    const { dir, worktreeDir } = await getWorktreePaths(filepath);
-    if (!dir) return [];
+  const { dir, worktreeDir } = await getWorktreePaths(filepath);
+  if (!dir) return [];
 
-    const ignore = worktreeDir ? (await getIgnore(worktreeDir, true)) : (await getIgnore(dir, true));
-    const relativePath = worktreeDir
-        ? path.relative(worktreeDir.toString(), filepath.toString())
-        : path.relative(dir.toString(), filepath.toString());
-    if (ignore.ignores(relativePath)) return [];
+  const ignore = worktreeDir ? await getIgnore(worktreeDir, true) : await getIgnore(dir, true);
+  const relativePath = worktreeDir
+    ? path.relative(worktreeDir.toString(), filepath.toString())
+    : path.relative(dir.toString(), filepath.toString());
+  if (ignore.ignores(relativePath)) return [];
 
-    const content = await readFileAsync(filepath, { encoding: 'utf-8' });
-    const conflicts = getConflictingChunks(content);
-    if (conflicts.length == 0) return [];
+  const content = (await readFileAsync(filepath, { encoding: 'utf-8' })).toString();
+  const conflicts = getConflictingChunks(content);
+  if (conflicts.length == 0) return [];
 
-    return [{ path: filepath, conflicts: conflicts }];
-}
+  return [{ path: filepath, conflicts: conflicts }];
+};
 
 const checkUnmergedDirectory = async (directory: PathLike): Promise<Conflict[]> => {
-    const result = await execute(`git diff --check`, directory.toString());
+  const result = await execute(`git diff --check`, directory.toString());
 
-    const conflictPattern = /(.+?)(?<=:)(\d)*(?=:)/gm; // Matches `<filename>:<position>` syntax, with a `:` positive lookbehind.
-    const conflictedFiles = new Map<string, number[]>();
-    result.stdout.match(conflictPattern)?.forEach(match => {
-        const [filename, position] = match.split(':').slice(0, 2) as [string, number];
-        const filepath = path.join(directory.toString(), filename);
-        const existing = conflictedFiles.get(filepath);
-        conflictedFiles.set(filepath, existing ? [...existing, position] : [position]);
-    });
-    return Array.from(conflictedFiles).map(c => ({ path: c[0], conflicts: c[1] }));
-}
+  const conflictPattern = /(.+?)(?<=:)(\d)*(?=:)/gm; // Matches `<filename>:<position>` syntax, with a `:` positive lookbehind.
+  const conflictedFiles = new Map<string, number[]>();
+  result.stdout.match(conflictPattern)?.forEach(match => {
+    const [filename, position] = match.split(':').slice(0, 2) as [string, number];
+    const filepath = path.join(directory.toString(), filename);
+    const existing = conflictedFiles.get(filepath);
+    conflictedFiles.set(filepath, existing ? [...existing, position] : [position]);
+  });
+  return Array.from(conflictedFiles).map(c => ({ path: c[0], conflicts: c[1] }));
+};
 
 /**
  * Check for conflicts in a base branch after attempting to merge.
@@ -154,38 +180,41 @@ const checkUnmergedDirectory = async (directory: PathLike): Promise<Conflict[]> 
  * @returns {Promise<Conflict[]>} A Promise object containing an array of conflict information found in the specified branch.
  */
 export const checkUnmergedBranch = async (dir: PathLike, branch: string): Promise<Conflict[]> => {
-    const branchRoot = await getBranchRoot(dir, branch);
-    const worktree = await getWorktreePaths(dir);
-    const current = await revParse({ dir: dir, options: ['abbrevRef'], args: 'HEAD' });
-    // skip any locally-tracked branches that are not checked out in the main worktree directory
-    const trackedLocalBranch = (branchRoot && worktree.dir) ? isEqualPaths(branchRoot, worktree.dir) && branch !== current : false;
-    if (!branchRoot || trackedLocalBranch) return [];
+  const branchRoot = await getBranchRoot(dir, branch);
+  const worktree = await getWorktreePaths(dir);
+  const current = await revParse({ dir: dir, options: ['abbrevRef'], args: 'HEAD' });
+  // skip any locally-tracked branches that are not checked out in the main worktree directory
+  const trackedLocalBranch =
+    branchRoot && worktree.dir
+      ? isEqualPaths(branchRoot, worktree.dir) && branch !== current
+      : false;
+  if (!branchRoot || trackedLocalBranch) return [];
 
-    const result = await execute(`git diff --check`, branchRoot.toString());
+  const result = await execute(`git diff --check`, branchRoot.toString());
 
-    const conflictPattern = /(.+?)(?<=:)(\d)*(?=:)/gm; // Matches `<filename>:<position>` syntax, with a `:` positive lookbehind.
-    const conflictedFiles = new Map<string, number[]>();
-    result.stdout.match(conflictPattern)?.forEach(match => {
-        const [filename, position] = match.split(':').slice(0, 2) as [string, number];
-        const filepath = path.join(branchRoot.toString(), filename);
-        const existing = conflictedFiles.get(filepath);
-        conflictedFiles.set(filepath, existing ? [...existing, position] : [position]);
-    });
-    return Array.from(conflictedFiles).map(c => ({ path: c[0], conflicts: c[1] }));
-}
+  const conflictPattern = /(.+?)(?<=:)(\d)*(?=:)/gm; // Matches `<filename>:<position>` syntax, with a `:` positive lookbehind.
+  const conflictedFiles = new Map<string, number[]>();
+  result.stdout.match(conflictPattern)?.forEach(match => {
+    const [filename, position] = match.split(':').slice(0, 2) as [string, number];
+    const filepath = path.join(branchRoot.toString(), filename);
+    const existing = conflictedFiles.get(filepath);
+    conflictedFiles.set(filepath, existing ? [...existing, position] : [position]);
+  });
+  return Array.from(conflictedFiles).map(c => ({ path: c[0], conflicts: c[1] }));
+};
 
 /**
- * Resolve the names of branches involved in an in-progress merge, given the root directory path of the base branch. If the base branch is a 
- * linked worktree, then this function will extract the branch names from the `GIT_DIR/worktrees/{branch}/MERGE_MSG` file which has 
+ * Resolve the names of branches involved in an in-progress merge, given the root directory path of the base branch. If the base branch is a
+ * linked worktree, then this function will extract the branch names from the `GIT_DIR/worktrees/{branch}/MERGE_MSG` file which has
  * content similar to:
  * ```bash
  * Merge remote-tracking branch 'origin/compare' into base
- * 
+ *
  * # Conflicts:
  * #	components/list/index.tsx
  * ```
- * 
- * If the base branch is located in the main worktree directory, then we extract the branch names from the GIT_DIR/MERGE_MSG file which has 
+ *
+ * If the base branch is located in the main worktree directory, then we extract the branch names from the GIT_DIR/MERGE_MSG file which has
  * content similar to:
  * ```bash
  * Merge branch 'compare'
@@ -195,48 +224,64 @@ export const checkUnmergedBranch = async (dir: PathLike, branch: string): Promis
  * ```
  *
  * @param root The root directory of the base branch involved in the merge; either a main or linked worktree path can be resolved.
- * @returns {Promise<{ base: string | undefined; compare: string | undefined; }>} A Promise object containing the base branch name (or 
+ * @returns {Promise<{ base: string | undefined; compare: string | undefined; }>} A Promise object containing the base branch name (or
  * undefined if not included in the `MERGE_MSG` file) and the compare branch name.
  */
-export const fetchMergingBranches = async (root: PathLike): Promise<{ base: string | undefined, compare: string | undefined }> => {
-    const branchPattern = /(?<=Merge( remote-tracking)? branch(es)? .*)('.+?')+/gm; // Match linked worktree and main worktree patterns
-    const { gitdir, worktreeLink } = await getWorktreePaths(root);
-    const mergeMsg = worktreeLink ? path.join(worktreeLink.toString(), 'MERGE_MSG') : gitdir ? path.join(gitdir.toString(), 'MERGE_MSG') : '';
-    const message = (await pathExists(mergeMsg)) ? await readFileAsync(mergeMsg, { encoding: 'utf-8' }) : '';
-    const match = message.match(branchPattern);
-    return match
-        ? match.length === 2
-            ? { base: (match[0] as string).replace(/['"]+/g, ''), compare: (match[1] as string).replace(/['"]+/g, '') }
-            : { base: undefined, compare: (match[0] as string).replace(/['"]+/g, '') }
-        : { base: undefined, compare: undefined };
+export const fetchMergingBranches = async (
+  root: PathLike
+): Promise<{ base: string | undefined; compare: string | undefined }> => {
+  const branchPattern = /(?<=Merge( remote-tracking)? branch(es)? .*)('.+?')+/gm; // Match linked worktree and main worktree patterns
+  const { gitdir, worktreeLink } = await getWorktreePaths(root);
+  const mergeMsg = worktreeLink
+    ? path.join(worktreeLink.toString(), 'MERGE_MSG')
+    : gitdir
+    ? path.join(gitdir.toString(), 'MERGE_MSG')
+    : '';
+  const message = (await pathExists(mergeMsg))
+    ? (await readFileAsync(mergeMsg, { encoding: 'utf-8' })).toString()
+    : '';
+  const match = message.match(branchPattern);
+  return match
+    ? match.length === 2
+      ? {
+          base: (match[0] as string).replace(/['"]+/g, ''),
+          compare: (match[1] as string).replace(/['"]+/g, '')
+        }
+      : { base: undefined, compare: (match[0] as string).replace(/['"]+/g, '') }
+    : { base: undefined, compare: undefined };
 };
 
-export const processMergeOutput = async (output: Awaited<ReturnType<typeof execute>>, root: PathLike): Promise<MergeOutput> => {
-    const failedPattern = new RegExp('(fatal|error):', 'gm');
-    const alreadyMergedPattern = new RegExp('Already up to date.', 'gm');
-    const conflictPattern = new RegExp('(?<=Merge conflict in ).*(?=\\r?\\n)', 'gm');
-    const fastForwardPattern = new RegExp('(?<!fatal.*)Fast-forward', 'gim');
-    const mergeStrategyPattern = new RegExp('Merge made by the \'(.*)\' strategy.', 'gm');
-    const rebasePattern = new RegExp('Successfully rebased and updated', 'gm');
+export const processMergeOutput = async (
+  output: Awaited<ReturnType<typeof execute>>,
+  root: PathLike
+): Promise<MergeOutput> => {
+  const failedPattern = new RegExp('(fatal|error):', 'gm');
+  const alreadyMergedPattern = new RegExp('Already up to date.', 'gm');
+  const conflictPattern = new RegExp('(?<=Merge conflict in ).*(?=\\r?\\n)', 'gm');
+  const fastForwardPattern = new RegExp('(?<!fatal.*)Fast-forward', 'gim');
+  const mergeStrategyPattern = new RegExp("Merge made by the '(.*)' strategy.", 'gm');
+  const rebasePattern = new RegExp('Successfully rebased and updated', 'gm');
 
-    const alreadyMerged = output.stdout.match(alreadyMergedPattern) ? true : false;
-    const fastForward = output.stdout.match(fastForwardPattern) ? true : false;
-    const conflicts = output.stdout.match(conflictPattern)?.map(filepath => path.resolve(root.toString(), filepath));
-    const rebaseStrategy = output.stdout.match(rebasePattern) ? true : false;
-    const mergeStrategy = mergeStrategyPattern.exec(output.stdout)?.[1];
-    const mergeCommit = mergeStrategy ? (await log({ dir: root }))[0]?.oid : undefined;
-    const failed = output.stderr.match(failedPattern) ? true : false;
+  const alreadyMerged = output.stdout.match(alreadyMergedPattern) ? true : false;
+  const fastForward = output.stdout.match(fastForwardPattern) ? true : false;
+  const conflicts = output.stdout
+    .match(conflictPattern)
+    ?.map(filepath => path.resolve(root.toString(), filepath));
+  const rebaseStrategy = output.stdout.match(rebasePattern) ? true : false;
+  const mergeStrategy = mergeStrategyPattern.exec(output.stdout)?.[1];
+  const mergeCommit = mergeStrategy ? (await log({ dir: root }))[0]?.oid : undefined;
+  const failed = output.stderr.match(failedPattern) ? true : false;
 
-    const mergeOutput: MergeOutput = {
-        status: failed || (conflicts && conflicts.length > 0) ? 'Failing' : 'Passing',
-        alreadyMerged: alreadyMerged,
-        fastForward: fastForward,
-        output: failed ? output.stderr : output.stdout,
-        ...removeNullableProperties({
-            mergeCommit: mergeCommit,
-            mergeStrategy: rebaseStrategy ? 'rebase' : mergeStrategy,
-            conflicts: conflicts
-        })
-    };
-    return mergeOutput;
+  const mergeOutput: MergeOutput = {
+    status: failed || (conflicts && conflicts.length > 0) ? 'Failing' : 'Passing',
+    alreadyMerged: alreadyMerged,
+    fastForward: fastForward,
+    output: failed ? output.stderr : output.stdout,
+    ...removeNullableProperties({
+      mergeCommit: mergeCommit,
+      mergeStrategy: rebaseStrategy ? 'rebase' : mergeStrategy,
+      conflicts: conflicts
+    })
+  };
+  return mergeOutput;
 };

--- a/src/containers/git/git-path.ts
+++ b/src/containers/git/git-path.ts
@@ -5,127 +5,154 @@ import { extractStats, isDirectory, readDirAsync, readFileAsync } from '../io';
 import { showBranch } from './git-show-branch';
 
 export type WorktreePaths = {
-    /** The main worktree root directory (e.g. *'/{project}'*), or `undefined` if not under version control. */
-    dir: PathLike | undefined;
-    /** The main worktree git directory (i.e. `GIT_DIR`, such as *'/{project}/.git'*), or `undefined` if not under version control). */
-    gitdir: PathLike | undefined;
-    /** The linked worktrees directory (i.e. `GIT_DIR/worktrees`, such as *'/{project}/.git/worktrees'*). */
-    worktrees: PathLike | undefined;
-    /** The linked worktree root directory (i.e. `/{project}/../.syn/{repo}/{branch}`), or `undefined` if not a linked worktree. */
-    worktreeDir: PathLike | undefined;
-    /** The linked worktree git file (e.g. *'/{project}/../.syn/{repo}/{branch}/.git'*, or `undefined` if not a linked worktree. */
-    worktreeGitdir: PathLike | undefined;
-    /**
-     * The direct link from linked worktree into the linked worktrees directory (i.e. `GIT_DIR/worktrees/{branch}`); this path
-     * is found in the linked worktree git file (`worktreeGitdir`).
-     */
-    worktreeLink: PathLike | undefined;
-}
+  /** The main worktree root directory (e.g. *'/{project}'*), or `undefined` if not under version control. */
+  dir: PathLike | undefined;
+  /** The main worktree git directory (i.e. `GIT_DIR`, such as *'/{project}/.git'*), or `undefined` if not under version control). */
+  gitdir: PathLike | undefined;
+  /** The linked worktrees directory (i.e. `GIT_DIR/worktrees`, such as *'/{project}/.git/worktrees'*). */
+  worktrees: PathLike | undefined;
+  /** The linked worktree root directory (i.e. `/{project}/../.syn/{repo}/{branch}`), or `undefined` if not a linked worktree. */
+  worktreeDir: PathLike | undefined;
+  /** The linked worktree git file (e.g. *'/{project}/../.syn/{repo}/{branch}/.git'*, or `undefined` if not a linked worktree. */
+  worktreeGitdir: PathLike | undefined;
+  /**
+   * The direct link from linked worktree into the linked worktrees directory (i.e. `GIT_DIR/worktrees/{branch}`); this path
+   * is found in the linked worktree git file (`worktreeGitdir`).
+   */
+  worktreeLink: PathLike | undefined;
+};
 
 /**
- * Find the root git directory. Starting at filepath, walks upward until it finds a directory that contains a *.git* subdirectory (i.e. the 
- * `dir` in the `WorktreePaths` type). In the case of linked worktrees (see [git-worktree](https://git-scm.com/docs/git-worktree)), this 
+ * Find the root git directory. Starting at filepath, walks upward until it finds a directory that contains a *.git* subdirectory (i.e. the
+ * `dir` in the `WorktreePaths` type). In the case of linked worktrees (see [git-worktree](https://git-scm.com/docs/git-worktree)), this
  * will find and return a directory that contains a *.git* file instead (i.e. the `worktreeDir` in the `WorktreePaths` type). The resulting
- * path is relative to the earliest directory in the given `filepath` (i.e. `/user/dir/file.txt` returns `/user/dir` even though 
+ * path is relative to the earliest directory in the given `filepath` (i.e. `/user/dir/file.txt` returns `/user/dir` even though
  * `/home/user/dir` might be the full path to that directory); this translates into absolute paths yielding absolute paths, and relative
  * paths yielding relative paths.
  *
  * @param filepath - The relative or absolute path to evaluate.
- * @returns {Promise<PathLike | undefined>} A Promise object containing the root git directory path, or undefined if no root git directory 
+ * @returns {Promise<PathLike | undefined>} A Promise object containing the root git directory path, or undefined if no root git directory
  * exists for the filepath (i.e. the filepath is not part of a Git repository).
  */
 export const getRoot = async (filepath: PathLike): Promise<PathLike | undefined> => {
-    const exists = await pathExists(filepath.toString());
-    if (!exists) throw new Error(`ENOENT: no such file or directory, getRoot '${filepath.toString()}'`);
+  const exists = await pathExists(filepath.toString());
+  if (!exists)
+    throw new Error(`ENOENT: no such file or directory, getRoot '${filepath.toString()}'`);
 
-    const matcher: ((directory: string) => (Match | Promise<Match>)) = async (directory: string) => {
-        const targetPath = join(directory, '.git');
-        return await pathExists(targetPath) ? directory : undefined;
-    }
+  const matcher: (directory: string) => Match | Promise<Match> = async (directory: string) => {
+    const targetPath = join(directory, '.git');
+    return (await pathExists(targetPath)) ? directory : undefined;
+  };
 
-    const dir = await findUp(matcher, { cwd: filepath.toString(), type: 'directory' });
-    if (!dir) return undefined;
+  const dir = await findUp(matcher, { cwd: filepath.toString(), type: 'directory' });
+  if (!dir) return undefined;
 
-    const parsed = parse(filepath.toString()); // does not output relative root for relative filepaths
-    const inputRoot = parsed.root.length > 0 ? parsed.root : filepath.toString().split(/[\\/]/)[0];
-    const root = inputRoot ? join(inputRoot, relative(inputRoot, dir)) : dir;
+  const parsed = parse(filepath.toString()); // does not output relative root for relative filepaths
+  const inputRoot = parsed.root.length > 0 ? parsed.root : filepath.toString().split(/[\\/]/)[0];
+  const root = inputRoot ? join(inputRoot, relative(inputRoot, dir)) : dir;
 
-    return normalize(root);
+  return normalize(root);
 };
 
 /**
- * Find the root git directory for a specific branch. For branches on a linked worktree, this corresponds to 
- * the `worktreeDir` in the `WorktreePaths` type. For all other locally tracked branches (i.e. branches that have 
+ * Find the root git directory for a specific branch. For branches on a linked worktree, this corresponds to
+ * the `worktreeDir` in the `WorktreePaths` type. For all other locally tracked branches (i.e. branches that have
  * previously been checked out), this corresponds to the `dir` in the `WorktreePaths` type.
  *
  * @param root - The relative or absolute path to a root directory (i.e. the `dir` or `worktreeDir` in the `WorktreePaths` type).
  * @param branch - Name of the target branch.
- * @returns {Promise<PathLike | undefined>} A Promise object containing the root git directory path, or undefined if no root git directory exists 
+ * @returns {Promise<PathLike | undefined>} A Promise object containing the root git directory path, or undefined if no root git directory exists
  * for the branch (i.e. the branch is remote-only or non-existent for the given repository).
  */
-export const getBranchRoot = async (root: PathLike, branch: string): Promise<PathLike | undefined> => {
-    const { dir, worktrees } = await getWorktreePaths(root);
-    const existsLocally = dir && (await showBranch({ dir: dir })).find(b => b.ref === branch) ? true : false;
-    if (!existsLocally) return undefined; // branch is either remote-only or non-existent
+export const getBranchRoot = async (
+  root: PathLike,
+  branch: string
+): Promise<PathLike | undefined> => {
+  const { dir, worktrees } = await getWorktreePaths(root);
+  const existsLocally =
+    dir && (await showBranch({ dir: dir })).find(b => b.ref === branch) ? true : false;
+  if (!existsLocally) return undefined; // branch is either remote-only or non-existent
 
-    // check to see if the branch matches one of the linked worktrees
-    const worktreeBranches = worktrees ? await readDirAsync(worktrees) : undefined;
-    const match = worktreeBranches ? worktreeBranches.find(w => w === branch) : undefined;
+  // check to see if the branch matches one of the linked worktrees
+  const worktreeBranches = worktrees ? await readDirAsync(worktrees) : undefined;
+  const match = worktreeBranches ? worktreeBranches.find(w => w === branch) : undefined;
 
-    // reading the `{dir}/.git/worktrees/{branch}/gitdir` file
-    const worktreeRoot = (match && worktrees)
-        ? dirname((await readFileAsync(join(worktrees.toString(), match, 'gitdir'), { encoding: 'utf-8' })).trim())
-        : undefined;
+  // reading the `{dir}/.git/worktrees/{branch}/gitdir` file
+  const worktreeRoot =
+    match && worktrees
+      ? dirname(
+          (await readFileAsync(join(worktrees.toString(), match, 'gitdir'), { encoding: 'utf-8' }))
+            .toString()
+            .trim()
+        )
+      : undefined;
 
-    return worktreeRoot ? worktreeRoot : dir;
-}
+  return worktreeRoot ? worktreeRoot : dir;
+};
 
 /**
- * Find the worktree paths required for handling objects tracked under git-based version control. This function is 
+ * Find the worktree paths required for handling objects tracked under git-based version control. This function is
  * capable of discerning paths maintained in linked worktrees and translating paths accordingly.
  *
  * @param target - The relative or absolute path to a file or directory.
- * @returns {Promise<WorktreePaths>} A `WorktreePaths` object containing all valid paths, and excluding any irrelevant paths (i.e. paths 
+ * @returns {Promise<WorktreePaths>} A `WorktreePaths` object containing all valid paths, and excluding any irrelevant paths (i.e. paths
  * associated with linked worktrees when the target is maintained in the main worktree directory).
  */
 export const getWorktreePaths = async (target: PathLike): Promise<WorktreePaths> => {
-    const root = await getRoot(target);
-    // check for target parameter being contained within a linked worktree
-    const isLinkedWorktree = root ? !(await isDirectory(join(root.toString(), '.git'))) : false;
-    // check for target parameter being contained within a `GIT_DIR/worktrees/{branch}` directory
-    const isWorktreesDir = root ? /^\.git([\\]+|\/)worktrees([\\]+|\/).+/.test(relative(root.toString(), target.toString())) : false;
+  const root = await getRoot(target);
+  // check for target parameter being contained within a linked worktree
+  const isLinkedWorktree = root ? !(await isDirectory(join(root.toString(), '.git'))) : false;
+  // check for target parameter being contained within a `GIT_DIR/worktrees/{branch}` directory
+  const isWorktreesDir = root
+    ? /^\.git([\\]+|\/)worktrees([\\]+|\/).+/.test(relative(root.toString(), target.toString()))
+    : false;
 
-    if (isWorktreesDir && root) {
-        const dir = root;
-        const gitdir = dir ? join(dir.toString(), '.git') : undefined;
-        const worktrees = gitdir ? join(gitdir, 'worktrees') : undefined;
-
-        const match = relative(dir.toString(), target.toString()).match(/(?<=^\.git[\\/]+worktrees[\\/]+)([^\\/\n]+)/);
-        const branch = match ? match[0] : undefined;
-
-        const worktreeGitdir = (worktrees && branch) ?
-            (await readFileAsync(join(worktrees, branch, 'gitdir'), { encoding: 'utf-8' })).trim() : undefined;
-        const worktreeDir = worktreeGitdir ? join(worktreeGitdir, '..') : undefined;
-        const worktreeGitdirExists = worktreeGitdir ? await pathExists(worktreeGitdir) : false;
-        const worktreeLink = worktreeGitdir && worktreeGitdirExists ?
-            (await readFileAsync(worktreeGitdir, { encoding: 'utf-8' })).slice('gitdir: '.length).trim() : undefined;
-
-        return { dir, gitdir, worktrees, worktreeDir, worktreeGitdir, worktreeLink };
-    }
-
-    // calculate paths associated with a linked worktree
-    const worktreeDir = isLinkedWorktree ? root : undefined;
-    const worktreeGitdir = worktreeDir ? join(worktreeDir.toString(), '.git') : undefined;
-    const worktreeLink = worktreeGitdir ?
-        (await readFileAsync(worktreeGitdir, { encoding: 'utf-8' })).slice('gitdir: '.length).trim() : undefined;
-
-    // calculate paths associated with the main worktree
-    const dir = !isLinkedWorktree ? root : (await getRoot(worktreeLink as string));
+  if (isWorktreesDir && root) {
+    const dir = root;
     const gitdir = dir ? join(dir.toString(), '.git') : undefined;
-    const worktreesPath = gitdir ? join(gitdir, 'worktrees') : undefined;
-    // verify that the `GIT_DIR/worktrees` directory exists
-    const worktrees = worktreesPath && !(await extractStats(worktreesPath)) ? undefined : worktreesPath;
+    const worktrees = gitdir ? join(gitdir, 'worktrees') : undefined;
+
+    const match = relative(dir.toString(), target.toString()).match(
+      /(?<=^\.git[\\/]+worktrees[\\/]+)([^\\/\n]+)/
+    );
+    const branch = match ? match[0] : undefined;
+
+    const worktreeGitdir =
+      worktrees && branch
+        ? (await readFileAsync(join(worktrees, branch, 'gitdir'), { encoding: 'utf-8' }))
+            .toString()
+            .trim()
+        : undefined;
+    const worktreeDir = worktreeGitdir ? join(worktreeGitdir, '..') : undefined;
+    const worktreeGitdirExists = worktreeGitdir ? await pathExists(worktreeGitdir) : false;
+    const worktreeLink =
+      worktreeGitdir && worktreeGitdirExists
+        ? (await readFileAsync(worktreeGitdir, { encoding: 'utf-8' }))
+            .toString()
+            .slice('gitdir: '.length)
+            .trim()
+        : undefined;
 
     return { dir, gitdir, worktrees, worktreeDir, worktreeGitdir, worktreeLink };
-}
+  }
 
+  // calculate paths associated with a linked worktree
+  const worktreeDir = isLinkedWorktree ? root : undefined;
+  const worktreeGitdir = worktreeDir ? join(worktreeDir.toString(), '.git') : undefined;
+  const worktreeLink = worktreeGitdir
+    ? (await readFileAsync(worktreeGitdir, { encoding: 'utf-8' }))
+        .toString()
+        .slice('gitdir: '.length)
+        .trim()
+    : undefined;
+
+  // calculate paths associated with the main worktree
+  const dir = !isLinkedWorktree ? root : await getRoot(worktreeLink as string);
+  const gitdir = dir ? join(dir.toString(), '.git') : undefined;
+  const worktreesPath = gitdir ? join(gitdir, 'worktrees') : undefined;
+  // verify that the `GIT_DIR/worktrees` directory exists
+  const worktrees =
+    worktreesPath && !(await extractStats(worktreesPath)) ? undefined : worktreesPath;
+
+  return { dir, gitdir, worktrees, worktreeDir, worktreeGitdir, worktreeLink };
+};

--- a/src/containers/io.ts
+++ b/src/containers/io.ts
@@ -176,7 +176,7 @@ export const isDescendant = (root: PathLike, filepath: PathLike, direct = false)
 export function readFileAsync(
   filepath: fs.PathLike,
   options: { flag: string } | { encoding: nodeEncoding; flag?: string }
-): Promise<string>;
+): Promise<string | Buffer>;
 export function readFileAsync(filepath: fs.PathLike): Promise<Buffer>;
 /**
  * Asynchronously read file contents into a Buffer or string.
@@ -216,7 +216,7 @@ export function readFileAsync(filepath: fs.PathLike): Promise<Buffer>;
 export function readFileAsync(
   filepath: fs.PathLike,
   options?: { flag: string } | { encoding: nodeEncoding; flag?: string }
-): Promise<string> | Promise<Buffer> {
+): Promise<string | Buffer> | Promise<Buffer> {
   const fullPath = path.resolve(filepath.toString());
   if (options) return fs.readFile(fullPath, options);
   else return fs.readFile(fullPath);

--- a/src/store/cache/FSCache.tsx
+++ b/src/store/cache/FSCache.tsx
@@ -14,108 +14,125 @@ import cardSelectors from '../selectors/cards';
 import metafileSelectors from '../selectors/metafiles';
 import { cacheRemoved, cacheUpdated } from '../slices/cache';
 import { Card } from '../slices/cards';
-import { isDirectoryMetafile, isFileMetafile, isFilebasedMetafile, metafileRemoved } from '../slices/metafiles';
+import {
+  isDirectoryMetafile,
+  isFileMetafile,
+  isFilebasedMetafile,
+  metafileRemoved
+} from '../slices/metafiles';
 import { fetchCache } from '../thunks/cache';
 import { fetchMetafile } from '../thunks/metafiles';
 
 export const FSCacheContext = createContext<ReturnMap<PathLike, FSWatcher>>([
-    new Map([]),
-    { set: () => null, setAll: () => null, remove: () => null, reset: () => null }
+  new Map([]),
+  { set: () => null, setAll: () => null, remove: () => null, reset: () => null }
 ]);
 
 const FSCacheServices = ({ children }: { children: ReactNode }) => {
-    const cacheIds = useAppSelector(state => cacheSelectors.selectIds(state));
-    const cards = useAppSelector(state => cardSelectors.selectAll(state));
-    const metafiles = useAppSelector(state => metafileSelectors.selectEntities(state));
-    const [watchers, watcherActions] = useContext(FSCacheContext);
-    const dispatch = useAppDispatch();
+  const cacheIds = useAppSelector(state => cacheSelectors.selectIds(state));
+  const cards = useAppSelector(state => cardSelectors.selectAll(state));
+  const metafiles = useAppSelector(state => metafileSelectors.selectEntities(state));
+  const [watchers, watcherActions] = useContext(FSCacheContext);
+  const dispatch = useAppDispatch();
 
-    useEffect(() => {
-        const asyncUpdate = async () => {
-            const diff = diffArrays(Array.from(watchers.keys()).map(k => k.toString()), cacheIds as string[]);
-            const added = flattenArray(diff.filter(change => change.added === true).map(change => change.value));
-            const removed = flattenArray(diff.filter(change => change.removed === true).map(change => change.value));
-            console.error(`FSCacheService useEffect updates... { added: ${added.length}, removed: ${removed.length} }`);
-            await Promise.all(added.map(filepath => eventHandler('add', filepath)));
-            await Promise.all(removed.map(filepath => eventHandler('unlink', filepath)));
+  useEffect(() => {
+    const asyncUpdate = async () => {
+      const diff = diffArrays(
+        Array.from(watchers.keys()).map(k => k.toString()),
+        cacheIds as string[]
+      );
+      const added = flattenArray(
+        diff.filter(change => change.added === true).map(change => change.value)
+      );
+      const removed = flattenArray(
+        diff.filter(change => change.removed === true).map(change => change.value)
+      );
+      console.error(
+        `FSCacheService useEffect updates... { added: ${added.length}, removed: ${removed.length} }`
+      );
+      await Promise.all(added.map(filepath => eventHandler('add', filepath)));
+      await Promise.all(removed.map(filepath => eventHandler('unlink', filepath)));
+    };
+    asyncUpdate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheIds]);
+
+  const selectByFilepath = (filepath: PathLike): Card | undefined => {
+    return cards.filter(c => {
+      const metafile = metafiles[c.metafile];
+      if (isDefined(metafile) && isFileMetafile(metafile)) {
+        return isEqualPaths(metafile.path, filepath);
+      } else if (isDefined(metafile) && isDirectoryMetafile(metafile)) {
+        return (
+          metafile.contains.filter(m => {
+            const child = metafiles[m];
+            return (
+              isDefined(child) && isFilebasedMetafile(child) && isEqualPaths(child.path, filepath)
+            );
+          }).length > 0
+        );
+      }
+    })[0];
+  };
+
+  const eventHandler = async (event: WatchEventType, filename: PathLike) => {
+    switch (event) {
+      case 'add': {
+        const stats = await extractStats(filename);
+        const metafile = await dispatch(fetchMetafile({ path: filename })).unwrap();
+        const card = selectByFilepath(filename);
+        const existing = watchers.has(filename);
+
+        if (!existing && card && stats && !stats.isDirectory()) {
+          // verify file exists on FS and is not a directory
+          const newWatcher = watch(filename.toString(), { ignoreInitial: true });
+          newWatcher.on('all', eventHandler);
+          watcherActions.set(filename, newWatcher);
+        } else if (!existing && !stats) {
+          dispatch(metafileRemoved(metafile.id));
         }
-        asyncUpdate();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [cacheIds]);
-
-    const selectByFilepath = (filepath: PathLike): Card | undefined => {
-        return cards.filter(c => {
-            const metafile = metafiles[c.metafile];
-            if (isDefined(metafile) && isFileMetafile(metafile)) {
-                return isEqualPaths(metafile.path, filepath);
-            } else if (isDefined(metafile) && isDirectoryMetafile(metafile)) {
-                return metafile.contains.filter(m => {
-                    const child = metafiles[m];
-                    return isDefined(child) && isFilebasedMetafile(child) && isEqualPaths(child.path, filepath);
-                }).length > 0;
-            }
-        })[0];
-    }
-
-    const eventHandler = async (event: WatchEventType, filename: PathLike) => {
-        switch (event) {
-            case 'add': {
-                const stats = await extractStats(filename);
-                const metafile = await dispatch(fetchMetafile({ path: filename })).unwrap();
-                const card = selectByFilepath(filename);
-                const existing = watchers.has(filename);
-
-
-                if (!existing && card && stats && !stats.isDirectory()) { // verify file exists on FS and is not a directory
-                    const newWatcher = watch(filename.toString(), { ignoreInitial: true });
-                    newWatcher.on('all', eventHandler);
-                    watcherActions.set(filename, newWatcher);
-                } else if (!existing && !stats) {
-                    dispatch(metafileRemoved(metafile.id));
-                }
-                break;
-            }
-            case 'change': {
-                const existing = await dispatch(fetchCache(filename.toString())).unwrap();
-                if (existing) {
-                    console.log(`FSCache change event: ${filename.toString()}`);
-                    dispatch(cacheUpdated({
-                        ...existing,
-                        content: createHash('md5').update(await readFileAsync(filename, { encoding: 'utf-8' })).digest('hex')
-                    }));
-                }
-                break;
-            }
-            case 'unlink': {
-                const watcher = watchers.get(filename);
-                if (watcher) watcher.close();
-                watcherActions.remove(filename);
-                dispatch(cacheRemoved(filename.toString()));
-                break;
-            }
-            case 'unlinkDir': {
-                console.error(`ERROR: FSCache saw 'unlinkDir' on ${filename.toString()}`);
-                break;
-            }
+        break;
+      }
+      case 'change': {
+        const existing = await dispatch(fetchCache(filename.toString())).unwrap();
+        if (existing) {
+          console.log(`FSCache change event: ${filename.toString()}`);
+          const content = (await readFileAsync(filename, { encoding: 'utf-8' })).toString();
+          dispatch(
+            cacheUpdated({
+              ...existing,
+              content: createHash('md5').update(content).digest('hex')
+            })
+          );
         }
+        break;
+      }
+      case 'unlink': {
+        const watcher = watchers.get(filename);
+        if (watcher) watcher.close();
+        watcherActions.remove(filename);
+        dispatch(cacheRemoved(filename.toString()));
+        break;
+      }
+      case 'unlinkDir': {
+        console.error(`ERROR: FSCache saw 'unlinkDir' on ${filename.toString()}`);
+        break;
+      }
     }
+  };
 
-    return (
-        <FSCacheContext.Provider value={[watchers, watcherActions]}>
-            {children}
-        </FSCacheContext.Provider>
-    );
-}
+  return (
+    <FSCacheContext.Provider value={[watchers, watcherActions]}>{children}</FSCacheContext.Provider>
+  );
+};
 
 export const FSCacheProvider = ({ children }: { children: ReactNode }) => {
-    // Map from absolute filepath to FSWatcher instance
-    const [watchers, watcherActions] = useMap<PathLike, FSWatcher>([]);
+  // Map from absolute filepath to FSWatcher instance
+  const [watchers, watcherActions] = useMap<PathLike, FSWatcher>([]);
 
-    return (
-        <FSCacheContext.Provider value={[watchers, watcherActions]}>
-            <FSCacheServices>
-                {children}
-            </FSCacheServices>
-        </FSCacheContext.Provider>
-    )
-}
+  return (
+    <FSCacheContext.Provider value={[watchers, watcherActions]}>
+      <FSCacheServices>{children}</FSCacheServices>
+    </FSCacheContext.Provider>
+  );
+};

--- a/src/store/thunks/branches.ts
+++ b/src/store/thunks/branches.ts
@@ -1,8 +1,22 @@
 import { PathLike } from 'fs-extra';
 import { normalize } from 'path';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import isBoolean from 'validator/lib/isBoolean';
-import { deleteBranch, fetchMergingBranches, getBranchRoot, getConfig, getRoot, getWorktreePaths, log, revParse, showBranch, worktreeAdd, worktreeList, worktreeRemove, worktreeStatus } from '../../containers/git';
+import {
+  deleteBranch,
+  fetchMergingBranches,
+  getBranchRoot,
+  getConfig,
+  getRoot,
+  getWorktreePaths,
+  log,
+  revParse,
+  showBranch,
+  worktreeAdd,
+  worktreeList,
+  worktreeRemove,
+  worktreeStatus
+} from '../../containers/git';
 import { ExactlyOne, isDefined, removeObjectProperty } from '../../containers/utils';
 import { createAppAsyncThunk } from '../hooks';
 import branchSelectors from '../selectors/branches';
@@ -15,186 +29,249 @@ import { fetchParentMetafile } from './metafiles';
 
 type BranchIdentifiers = Pick<Branch, 'ref' | 'root' | 'scope'>;
 
-export const fetchBranch = createAppAsyncThunk<Branch | undefined, ExactlyOne<{ branchIdentifiers: BranchIdentifiers, metafile: FilebasedMetafile }>>(
-    'branches/fetchBranch',
-    async (input, thunkAPI) => {
-        const state = thunkAPI.getState();
+export const fetchBranch = createAppAsyncThunk<
+  Branch | undefined,
+  ExactlyOne<{ branchIdentifiers: BranchIdentifiers; metafile: FilebasedMetafile }>
+>('branches/fetchBranch', async (input, thunkAPI) => {
+  const state = thunkAPI.getState();
 
-        if (input.branchIdentifiers) {
-            // check for a directly matching branch before using any expensive methods
-            const branch = branchSelectors.selectByRef(state, input.branchIdentifiers.root, input.branchIdentifiers.ref, input.branchIdentifiers.scope);
-            if (branch) return branch;
-        }
+  if (input.branchIdentifiers) {
+    // check for a directly matching branch before using any expensive methods
+    const branch = branchSelectors.selectByRef(
+      state,
+      input.branchIdentifiers.root,
+      input.branchIdentifiers.ref,
+      input.branchIdentifiers.scope
+    );
+    if (branch) return branch;
+  }
 
-        const root = input.metafile ? await getRoot(input.metafile.path) : input.branchIdentifiers.root;
-        const current = input.metafile && root ? (await revParse({ dir: root, options: ['abbrevRef'], args: 'HEAD' })) : undefined;
-        const ref = input.metafile ? current : input.branchIdentifiers.ref;
-        const scope = input.metafile ? 'local' : input.branchIdentifiers.scope;
+  const root = input.metafile ? await getRoot(input.metafile.path) : input.branchIdentifiers.root;
+  const current =
+    input.metafile && root
+      ? await revParse({ dir: root, options: ['abbrevRef'], args: 'HEAD' })
+      : undefined;
+  const ref = input.metafile ? current : input.branchIdentifiers.ref;
+  const scope = input.metafile ? 'local' : input.branchIdentifiers.scope;
 
-        if (input.metafile) {
-            // if metafile already has a branch UUID, check for matching branch
-            let branch = isVersionedMetafile(input.metafile) ? branchSelectors.selectById(state, input.metafile.branch) : undefined;
-            if (branch) return branch;
+  if (input.metafile) {
+    // if metafile already has a branch UUID, check for matching branch
+    let branch = isVersionedMetafile(input.metafile)
+      ? branchSelectors.selectById(state, input.metafile.branch)
+      : undefined;
+    if (branch) return branch;
 
-            // otherwise if parent metafile already has a branch UUID, check for matching branch
-            const parent = !branch ? await thunkAPI.dispatch(fetchParentMetafile(input.metafile)).unwrap() : undefined;
-            branch = (parent && isVersionedMetafile(parent)) ? branchSelectors.selectById(state, parent.branch) : branch;
-            if (branch) return branch;
+    // otherwise if parent metafile already has a branch UUID, check for matching branch
+    const parent = !branch
+      ? await thunkAPI.dispatch(fetchParentMetafile(input.metafile)).unwrap()
+      : undefined;
+    branch =
+      parent && isVersionedMetafile(parent)
+        ? branchSelectors.selectById(state, parent.branch)
+        : branch;
+    if (branch) return branch;
 
-            // otherwise check for the current branch in the root git directory (calculated from the metafile)
-            branch = root && ref ? branchSelectors.selectByRef(state, root, ref, scope) : undefined;
-            if (branch) return branch;
-        }
+    // otherwise check for the current branch in the root git directory (calculated from the metafile)
+    branch = root && ref ? branchSelectors.selectByRef(state, root, ref, scope) : undefined;
+    if (branch) return branch;
+  }
 
-        const branch = root && ref ? await thunkAPI.dispatch(buildBranch({ ref, root, scope })).unwrap() : undefined;
-        return branch;
-    }
-);
+  const branch =
+    root && ref ? await thunkAPI.dispatch(buildBranch({ ref, root, scope })).unwrap() : undefined;
+  return branch;
+});
 
-export const fetchBranches = createAppAsyncThunk<{ local: Branch[], remote: Branch[] }, PathLike>(
-    'branches/fetchBranches',
-    async (root, thunkAPI) => {
-        const branches = await showBranch({ dir: root, all: true });
-        const local = (await Promise.all(branches.filter(branch => branch.scope === 'local')
-            .filter(branch => branch.ref !== 'HEAD')
-            .map(branch => thunkAPI.dispatch(fetchBranch({ branchIdentifiers: { root: root, ref: branch.ref, scope: 'local' } })).unwrap())
-        )).filter(isDefined);
-        const remote = (await Promise.all(branches.filter(branch => branch.scope === 'remote')
-            .filter(branch => branch.ref !== 'HEAD')
-            .map(branch => thunkAPI.dispatch(fetchBranch({ branchIdentifiers: { root: root, ref: branch.ref, scope: 'remote' } })).unwrap())
-        )).filter(isDefined);
-        return { local, remote };
-    }
+export const fetchBranches = createAppAsyncThunk<{ local: Branch[]; remote: Branch[] }, PathLike>(
+  'branches/fetchBranches',
+  async (root, thunkAPI) => {
+    const branches = await showBranch({ dir: root, all: true });
+    const local = (
+      await Promise.all(
+        branches
+          .filter(branch => branch.scope === 'local')
+          .filter(branch => branch.ref !== 'HEAD')
+          .map(branch =>
+            thunkAPI
+              .dispatch(
+                fetchBranch({ branchIdentifiers: { root: root, ref: branch.ref, scope: 'local' } })
+              )
+              .unwrap()
+          )
+      )
+    ).filter(isDefined);
+    const remote = (
+      await Promise.all(
+        branches
+          .filter(branch => branch.scope === 'remote')
+          .filter(branch => branch.ref !== 'HEAD')
+          .map(branch =>
+            thunkAPI
+              .dispatch(
+                fetchBranch({ branchIdentifiers: { root: root, ref: branch.ref, scope: 'remote' } })
+              )
+              .unwrap()
+          )
+      )
+    ).filter(isDefined);
+    return { local, remote };
+  }
 );
 
 /**
  * Create a Branch object that is added to the Redux store. This function does not create git branches within
- * a repository worktree (i.e. it does not interact with the filesystem). Instead, this function updates the 
+ * a repository worktree (i.e. it does not interact with the filesystem). Instead, this function updates the
  * store state to reflect any newly created branches.
  */
 export const buildBranch = createAppAsyncThunk<Branch, BranchIdentifiers>(
-    'branches/buildBranch',
-    async (identifiers, thunkAPI) => {
+  'branches/buildBranch',
+  async (identifiers, thunkAPI) => {
+    const branchRoot: Awaited<ReturnType<typeof getBranchRoot>> = await getBranchRoot(
+      identifiers.root,
+      identifiers.ref
+    );
+    const root: PathLike =
+      identifiers.scope === 'local' && branchRoot ? branchRoot : identifiers.root;
+    const { dir, gitdir, worktreeDir, worktreeGitdir } = await getWorktreePaths(root);
 
-        const branchRoot: Awaited<ReturnType<typeof getBranchRoot>> = await getBranchRoot(identifiers.root, identifiers.ref);
-        const root: PathLike = (identifiers.scope === 'local' && branchRoot) ? branchRoot : identifiers.root;
-        const { dir, gitdir, worktreeDir, worktreeGitdir } = await getWorktreePaths(root);
+    const rootGitdir = worktreeGitdir ? worktreeGitdir : gitdir ? gitdir : '';
+    const linked = isDefined(worktreeDir);
+    const config = await getConfig({
+      dir: dir ? dir : root,
+      keyPath: `branch.${identifiers.ref}.remote`
+    });
+    const remote = config && config.scope !== 'none' ? config.value : 'origin';
+    const commits = await log({
+      dir: root,
+      revRange:
+        identifiers.scope === 'local' ? identifiers.ref : `remotes/${remote}/${identifiers.ref}`
+    });
+    const status = (await worktreeStatus({ dir: root }))?.status ?? 'uncommitted';
+    const head = commits.length > 0 ? (commits[0] as CommitObject).oid : '';
+    const revBare = await revParse({ dir: root, options: ['isBareRepository'] });
+    const bare = (revBare !== undefined && isBoolean(revBare)) ?? Boolean(revBare);
 
-        const rootGitdir = worktreeGitdir ? worktreeGitdir : gitdir ? gitdir : '';
-        const linked = isDefined(worktreeDir);
-        const config = await getConfig({ dir: dir ? dir : root, keyPath: `branch.${identifiers.ref}.remote` });
-        const remote = (config && config.scope !== 'none') ? config.value : 'origin';
-        const commits = await log({ dir: root, revRange: identifiers.scope === 'local' ? identifiers.ref : `remotes/${remote}/${identifiers.ref}` });
-        const status = (await worktreeStatus({ dir: root }))?.status ?? 'uncommitted';
-        const head = commits.length > 0 ? (commits[0] as CommitObject).oid : '';
-        const revBare = await revParse({ dir: root, options: ['isBareRepository'] });
-        const bare = (revBare !== undefined && isBoolean(revBare)) ?? Boolean(revBare);
-
-        return thunkAPI.dispatch(branchAdded({
-            id: v4(),
-            scope: identifiers.scope,
-            ref: identifiers.ref,
-            linked: linked,
-            bare: bare,
-            root: root,
-            gitdir: rootGitdir,
-            remote: remote,
-            status: status,
-            commits: commits,
-            head: head
-        })).payload;
-    }
+    return thunkAPI.dispatch(
+      branchAdded({
+        id: randomUUID(),
+        scope: identifiers.scope,
+        ref: identifiers.ref,
+        linked: linked,
+        bare: bare,
+        root: root,
+        gitdir: rootGitdir,
+        remote: remote,
+        status: status,
+        commits: commits,
+        head: head
+      })
+    ).payload;
+  }
 );
 
 /**
- * Checkout a branch in a {@link https://git-scm.com/docs/git-worktree linked worktree} and return a Branch object representing 
+ * Checkout a branch in a {@link https://git-scm.com/docs/git-worktree linked worktree} and return a Branch object representing
  * the updated branch information.
- * 
+ *
  * @param obj - A destructed object for named parameters.
  * @param obj.ref - The name of the branch to checkout.
  * @param obj.root - The relative or absolute path to the repository root directory (i.e. the `dir` in the `WorktreePaths` type).
  * @returns {Branch} A new Branch object representing the updated worktree information, or an existing Branch if `ref` matches
  * the existing current branch in the repository root directory.
  */
-export const addBranch = createAppAsyncThunk<Branch | undefined, { ref: string, root: PathLike }>(
-    'branches/addBranch',
-    async ({ ref, root }, thunkAPI) => {
-        const state = thunkAPI.getState();
+export const addBranch = createAppAsyncThunk<Branch | undefined, { ref: string; root: PathLike }>(
+  'branches/addBranch',
+  async ({ ref, root }, thunkAPI) => {
+    const state = thunkAPI.getState();
 
-        // check whether ref matches the current branch in the repository root path, if so return a metafile for it
-        const current = await revParse({ dir: root, options: ['abbrevRef'], args: 'HEAD' })
-        if (ref === current) return await thunkAPI
-            .dispatch(fetchBranch({ branchIdentifiers: { root: root, ref: ref, scope: 'local' } }))
-            .unwrap();
+    // check whether ref matches the current branch in the repository root path, if so return a metafile for it
+    const current = await revParse({ dir: root, options: ['abbrevRef'], args: 'HEAD' });
+    if (ref === current)
+      return await thunkAPI
+        .dispatch(fetchBranch({ branchIdentifiers: { root: root, ref: ref, scope: 'local' } }))
+        .unwrap();
 
-        // check whether a linked worktree has already been created for ref
-        const repo = repoSelectors.selectByRoot(state, root);
-        // the current branch is included in `worktrees`, but that case is already handled above so we won't be searching for it
-        const worktrees: Awaited<ReturnType<typeof worktreeList>> = repo ? await worktreeList({ dir: repo.root }) : [];
-        const existingWorktree = worktrees.find(w => w.ref === ref);
+    // check whether a linked worktree has already been created for ref
+    const repo = repoSelectors.selectByRoot(state, root);
+    // the current branch is included in `worktrees`, but that case is already handled above so we won't be searching for it
+    const worktrees: Awaited<ReturnType<typeof worktreeList>> = repo
+      ? await worktreeList({ dir: repo.root })
+      : [];
+    const existingWorktree = worktrees.find(w => w.ref === ref);
 
-        // if no linked worktree exists then create it, and then update the branch as needed before fetching the new metafile
-        const linkedRoot = existingWorktree
-            ? existingWorktree.root
-            : repo
-                ? normalize(`${root.toString()}/../.syn/${repo.name}/${ref}`)
-                : undefined;
-        if (linkedRoot) {
-            if (!existingWorktree) await worktreeAdd({ dir: root, path: linkedRoot, commitish: ref });
-            return await thunkAPI.dispatch(fetchBranch({ branchIdentifiers: { root: linkedRoot, ref: ref, scope: 'local' } })).unwrap();
-        }
-        return undefined;
+    // if no linked worktree exists then create it, and then update the branch as needed before fetching the new metafile
+    const linkedRoot = existingWorktree
+      ? existingWorktree.root
+      : repo
+      ? normalize(`${root.toString()}/../.syn/${repo.name}/${ref}`)
+      : undefined;
+    if (linkedRoot) {
+      if (!existingWorktree) await worktreeAdd({ dir: root, path: linkedRoot, commitish: ref });
+      return await thunkAPI
+        .dispatch(
+          fetchBranch({ branchIdentifiers: { root: linkedRoot, ref: ref, scope: 'local' } })
+        )
+        .unwrap();
     }
+    return undefined;
+  }
 );
 
 /**
  * Remove a Branch object from the Redux store. This will delete the local branch (including in a linked worktree), but will
  * not alter any remote branches associated with the repository. This function does interact with the filesystem in order to
  * remove the target branch and update the branches in the repository according to the Redux store.
- * 
+ *
  * @param obj - A destructed object for named parameters.
  * @param obj.repoId - The UUID of a Repository object found in the Redux store.
  * @param obj.branch - The name of the branch to remove.
  * @returns {boolean} A boolean indicating whether the branch was successfully removed.
  */
-export const removeBranch = createAppAsyncThunk<boolean, { repoId: UUID, branch: Branch }>(
-    'branches/removeBranch',
-    async ({ repoId, branch }, thunkAPI) => {
-        const state = thunkAPI.getState();
+export const removeBranch = createAppAsyncThunk<boolean, { repoId: UUID; branch: Branch }>(
+  'branches/removeBranch',
+  async ({ repoId, branch }, thunkAPI) => {
+    const state = thunkAPI.getState();
 
-        const repo = repoSelectors.selectById(state, repoId);
-        if (!repo) return false;
-        const current = await revParse({ dir: repo.root, options: ['abbrevRef'], args: 'HEAD' });
-        if (branch.ref === current) return false;
-        const worktreeRemoved = branch.linked ? await worktreeRemove({ dir: branch.root, worktree: branch.ref }) : true;
-        const branchRemoved = repo ? await deleteBranch({ dir: repo.root, branchName: branch.ref, force: true }) : false;
-        await thunkAPI.dispatch(updateBranches(repo));
+    const repo = repoSelectors.selectById(state, repoId);
+    if (!repo) return false;
+    const current = await revParse({ dir: repo.root, options: ['abbrevRef'], args: 'HEAD' });
+    if (branch.ref === current) return false;
+    const worktreeRemoved = branch.linked
+      ? await worktreeRemove({ dir: branch.root, worktree: branch.ref })
+      : true;
+    const branchRemoved = repo
+      ? await deleteBranch({ dir: repo.root, branchName: branch.ref, force: true })
+      : false;
+    await thunkAPI.dispatch(updateBranches(repo));
 
-        return worktreeRemoved && branchRemoved;
-    }
+    return worktreeRemoved && branchRemoved;
+  }
 );
 
 /**
- * Update the root directory path and linked worktree status of a Branch to reflect the current filesystem and git 
+ * Update the root directory path and linked worktree status of a Branch to reflect the current filesystem and git
  * status of a branch. Also appends/removes merging information in the case of an in-progress merge where this branch
  * is the base. This function updates the store state to reflect any recent changes to these fields.
  */
 export const updateBranch = createAppAsyncThunk<Branch, Branch>(
-    'branches/updateBranch',
-    async (branch, thunkAPI) => {
-        const branchRoot = await getBranchRoot(branch.root, branch.ref);
-        const root = (branch.scope === 'local' && branchRoot) ? branchRoot : branch.root;
-        const { worktreeDir } = await getWorktreePaths(root);
+  'branches/updateBranch',
+  async (branch, thunkAPI) => {
+    const branchRoot = await getBranchRoot(branch.root, branch.ref);
+    const root = branch.scope === 'local' && branchRoot ? branchRoot : branch.root;
+    const { worktreeDir } = await getWorktreePaths(root);
 
-        const linked = isDefined(worktreeDir);
-        const updatedRoot = linked ? worktreeDir : branch.root;
-        const status = (await worktreeStatus({ dir: updatedRoot }))?.status ?? 'uncommitted';
-        const merging = (await fetchMergingBranches(updatedRoot))?.compare;
+    const linked = isDefined(worktreeDir);
+    const updatedRoot = linked ? worktreeDir : branch.root;
+    const status = (await worktreeStatus({ dir: updatedRoot }))?.status ?? 'uncommitted';
+    const merging = (await fetchMergingBranches(updatedRoot))?.compare;
 
-        const updates: Branch = { ...branch, linked: linked, root: updatedRoot, status: status };
-        const updatedBranch = merging ? { ...updates, merging: merging } : isMergingBranch(updates) ? removeObjectProperty(updates, 'merging') : updates;
-        return thunkAPI.dispatch(branchReplaced(updatedBranch)).payload;
-    }
+    const updates: Branch = { ...branch, linked: linked, root: updatedRoot, status: status };
+    const updatedBranch = merging
+      ? { ...updates, merging: merging }
+      : isMergingBranch(updates)
+      ? removeObjectProperty(updates, 'merging')
+      : updates;
+    return thunkAPI.dispatch(branchReplaced(updatedBranch)).payload;
+  }
 );
 
 /**
@@ -203,11 +280,14 @@ export const updateBranch = createAppAsyncThunk<Branch, Branch>(
  * git repository on the filesystem.
  */
 export const updateBranches = createAppAsyncThunk<Repository, Repository>(
-    'branches/updateBranches',
-    async (repo, thunkAPI) => {
-        const branches = await thunkAPI.dispatch(fetchBranches(repo.root)).unwrap();
-        await Promise.all(branches.local.map(branch => thunkAPI.dispatch(updateBranch(branch))));
-        const branchIds = { local: branches.local.map(b => b.id), remote: branches.remote.map(b => b.id) };
-        return thunkAPI.dispatch(repoUpdated({ ...repo, ...branchIds })).payload;
-    }
+  'branches/updateBranches',
+  async (repo, thunkAPI) => {
+    const branches = await thunkAPI.dispatch(fetchBranches(repo.root)).unwrap();
+    await Promise.all(branches.local.map(branch => thunkAPI.dispatch(updateBranch(branch))));
+    const branchIds = {
+      local: branches.local.map(b => b.id),
+      remote: branches.remote.map(b => b.id)
+    };
+    return thunkAPI.dispatch(repoUpdated({ ...repo, ...branchIds })).payload;
+  }
 );

--- a/src/store/thunks/cache.ts
+++ b/src/store/thunks/cache.ts
@@ -7,52 +7,65 @@ import { Cache, cacheRemoved, cacheUpdated } from '../slices/cache';
 import { UUID } from '../types';
 
 export const fetchCache = createAppAsyncThunk<Cache | undefined, PathLike>(
-    'cache/fetch',
-    async (path, thunkAPI) => {
-        return cacheSelectors.selectById(thunkAPI.getState(), path.toString());
-    }
+  'cache/fetch',
+  async (path, thunkAPI) => {
+    return cacheSelectors.selectById(thunkAPI.getState(), path.toString());
+  }
 );
 
-export const subscribeCache = createAppAsyncThunk<Cache, { path: PathLike, card: UUID }>(
-    'cache/subscribe',
-    async ({ path, card }, thunkAPI) => {
-        const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
-        const reserved = existing ? existing.reserved.includes(card) ? existing.reserved : [...existing.reserved, card] : [card];
+export const subscribeCache = createAppAsyncThunk<Cache, { path: PathLike; card: UUID }>(
+  'cache/subscribe',
+  async ({ path, card }, thunkAPI) => {
+    const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
+    const reserved = existing
+      ? existing.reserved.includes(card)
+        ? existing.reserved
+        : [...existing.reserved, card]
+      : [card];
+    const content = (await readFileAsync(path, { encoding: 'utf-8' })).toString();
 
-        return thunkAPI.dispatch(cacheUpdated({
-            path: path.toString(),
-            reserved: reserved,
-            content: createHash('md5').update(await readFileAsync(path, { encoding: 'utf-8' })).digest('hex')
-        })).payload;
-    }
+    return thunkAPI.dispatch(
+      cacheUpdated({
+        path: path.toString(),
+        reserved: reserved,
+        content: createHash('md5').update(content).digest('hex')
+      })
+    ).payload;
+  }
 );
 
-export const subscribeCacheAll = createAppAsyncThunk<Cache[], { paths: PathLike[], card: UUID }>(
-    'cache/subscribeAll',
-    async ({ paths, card }, thunkAPI) => {
-        return await Promise.all(paths.map(async p => await thunkAPI.dispatch(subscribeCache({ path: p, card: card })).unwrap()));
-    }
+export const subscribeCacheAll = createAppAsyncThunk<Cache[], { paths: PathLike[]; card: UUID }>(
+  'cache/subscribeAll',
+  async ({ paths, card }, thunkAPI) => {
+    return await Promise.all(
+      paths.map(
+        async p => await thunkAPI.dispatch(subscribeCache({ path: p, card: card })).unwrap()
+      )
+    );
+  }
 );
 
-export const unsubscribeCache = createAppAsyncThunk<undefined, { path: PathLike, card: UUID }>(
-    'cache/unsubscribe',
-    async ({ path, card }, thunkAPI) => {
-        const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
-        if (existing?.reserved.includes(card)) {
-            const updated = thunkAPI.dispatch(cacheUpdated({
-                ...existing,
-                reserved: existing.reserved.filter(c => c != card)
-            })).payload;
-            if (updated.reserved.length === 0) thunkAPI.dispatch(cacheRemoved(existing.path));
-        }
-        return undefined;
+export const unsubscribeCache = createAppAsyncThunk<undefined, { path: PathLike; card: UUID }>(
+  'cache/unsubscribe',
+  async ({ path, card }, thunkAPI) => {
+    const existing = cacheSelectors.selectById(thunkAPI.getState(), path.toString());
+    if (existing?.reserved.includes(card)) {
+      const updated = thunkAPI.dispatch(
+        cacheUpdated({
+          ...existing,
+          reserved: existing.reserved.filter(c => c != card)
+        })
+      ).payload;
+      if (updated.reserved.length === 0) thunkAPI.dispatch(cacheRemoved(existing.path));
     }
+    return undefined;
+  }
 );
 
-export const unsubscribeCacheAll = createAppAsyncThunk<undefined, { paths: PathLike[], card: UUID }>(
-    'cache/unsubscribeAll',
-    async ({ paths, card }, thunkAPI) => {
-        paths.forEach(async p => await thunkAPI.dispatch(unsubscribeCache({ path: p, card: card })));
-        return undefined;
-    }
-);
+export const unsubscribeCacheAll = createAppAsyncThunk<
+  undefined,
+  { paths: PathLike[]; card: UUID }
+>('cache/unsubscribeAll', async ({ paths, card }, thunkAPI) => {
+  paths.forEach(async p => await thunkAPI.dispatch(unsubscribeCache({ path: p, card: card })));
+  return undefined;
+});

--- a/src/store/thunks/cards.ts
+++ b/src/store/thunks/cards.ts
@@ -1,6 +1,6 @@
 import { PathLike } from 'fs-extra';
 import { DateTime } from 'luxon';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { ExactlyOne, getRandomInt } from '../../containers/utils';
 import { extractFilename } from '../../containers/io';
 import { createAppAsyncThunk } from '../hooks';
@@ -8,51 +8,59 @@ import { Card, cardAdded, cardUpdated } from '../slices/cards';
 import { Metafile } from '../slices/metafiles';
 import { createMetafile, fetchMetafile } from './metafiles';
 
-export const buildCard = createAppAsyncThunk<Card, ExactlyOne<{ path: PathLike, metafile: Metafile }>>(
-    'cards/buildCard',
-    async (input, thunkAPI) => {
-        let card: Card = thunkAPI.dispatch(cardAdded({
-            id: v4(),
-            name: input.metafile ? input.metafile.name : extractFilename(input.path),
-            created: DateTime.local().valueOf(),
-            modified: DateTime.local().valueOf(),
-            captured: undefined,
-            expanded: false,
-            zIndex: 1,
-            left: getRandomInt(10, 70),
-            top: getRandomInt(70, 130),
-            type: input.metafile ? input.metafile.handler : 'Loading',
-            metafile: input.metafile ? input.metafile.id : '',
-            classes: []
-        })).payload;
+export const buildCard = createAppAsyncThunk<
+  Card,
+  ExactlyOne<{ path: PathLike; metafile: Metafile }>
+>('cards/buildCard', async (input, thunkAPI) => {
+  let card: Card = thunkAPI.dispatch(
+    cardAdded({
+      id: randomUUID(),
+      name: input.metafile ? input.metafile.name : extractFilename(input.path),
+      created: DateTime.local().valueOf(),
+      modified: DateTime.local().valueOf(),
+      captured: undefined,
+      expanded: false,
+      zIndex: 1,
+      left: getRandomInt(10, 70),
+      top: getRandomInt(70, 130),
+      type: input.metafile ? input.metafile.handler : 'Loading',
+      metafile: input.metafile ? input.metafile.id : '',
+      classes: []
+    })
+  ).payload;
 
-        if (input.path) {
-            const metafile = await thunkAPI.dispatch(fetchMetafile({ path: input.path })).unwrap();
-            if (metafile) {
-                card = thunkAPI.dispatch(cardUpdated({
-                    ...card,
-                    name: metafile.name,
-                    type: metafile.handler,
-                    metafile: metafile.id
-                })).payload;
-            }
-        }
-        return card;
+  if (input.path) {
+    const metafile = await thunkAPI.dispatch(fetchMetafile({ path: input.path })).unwrap();
+    if (metafile) {
+      card = thunkAPI.dispatch(
+        cardUpdated({
+          ...card,
+          name: metafile.name,
+          type: metafile.handler,
+          metafile: metafile.id
+        })
+      ).payload;
     }
-);
+  }
+  return card;
+});
 
 export const addBranchCard = createAppAsyncThunk<Card, void>(
-    'cards/addBranchCard',
-    async (_, thunkAPI) => {
-        const metafile = await thunkAPI.dispatch(createMetafile({
-            metafile: {
-                name: 'Branches',
-                modified: DateTime.local().valueOf(),
-                handler: 'Branches',
-                filetype: 'Text',
-                flags: []
-            }
-        })).unwrap();
-        return await thunkAPI.dispatch(buildCard({ metafile })).unwrap();
-    }
+  'cards/addBranchCard',
+  async (_, thunkAPI) => {
+    const metafile = await thunkAPI
+      .dispatch(
+        createMetafile({
+          metafile: {
+            name: 'Branches',
+            modified: DateTime.local().valueOf(),
+            handler: 'Branches',
+            filetype: 'Text',
+            flags: []
+          }
+        })
+      )
+      .unwrap();
+    return await thunkAPI.dispatch(buildCard({ metafile })).unwrap();
+  }
 );

--- a/src/store/thunks/filetypes.ts
+++ b/src/store/thunks/filetypes.ts
@@ -1,4 +1,4 @@
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { PathLike } from 'fs';
 import { createAppAsyncThunk } from '../hooks';
 import { Filetype, filetypeAdded } from '../slices/filetypes';
@@ -6,23 +6,23 @@ import { extractExtension, extractStats } from '../../containers/io';
 import filetypeSelectors from '../selectors/filetypes';
 
 export const fetchFiletype = createAppAsyncThunk<Filetype | undefined, PathLike>(
-    'filetypes/fetchFiletype',
-    async (filepath, thunkAPI) => {
-        const state = thunkAPI.getState();
-        const stats = await extractStats(filepath);
-        const result = (stats && stats.isDirectory()) ?
-            filetypeSelectors.selectByFiletype(state, 'Directory') :
-            filetypeSelectors.selectByExtension(state, extractExtension(filepath));
-        return result.length > 0 ? result[0] : filetypeSelectors.selectByFiletype(state, 'Text')[0];
-    }
+  'filetypes/fetchFiletype',
+  async (filepath, thunkAPI) => {
+    const state = thunkAPI.getState();
+    const stats = await extractStats(filepath);
+    const result =
+      stats && stats.isDirectory()
+        ? filetypeSelectors.selectByFiletype(state, 'Directory')
+        : filetypeSelectors.selectByExtension(state, extractExtension(filepath));
+    return result.length > 0 ? result[0] : filetypeSelectors.selectByFiletype(state, 'Text')[0];
+  }
 );
 
 export const importFiletypes = createAppAsyncThunk<void, Omit<Filetype, 'id'>[]>(
-    'filetypes/importFiletypes',
-    async (filetypes, thunkAPI) => {
-        filetypes.map(filetype => {
-            thunkAPI.dispatch(filetypeAdded({ id: v4(), ...filetype }));
-        });
-    }
-)
-
+  'filetypes/importFiletypes',
+  async (filetypes, thunkAPI) => {
+    filetypes.map(filetype => {
+      thunkAPI.dispatch(filetypeAdded({ id: randomUUID(), ...filetype }));
+    });
+  }
+);

--- a/src/store/thunks/metafiles.ts
+++ b/src/store/thunks/metafiles.ts
@@ -1,7 +1,7 @@
 import { PathLike } from 'fs-extra';
 import { DateTime } from 'luxon';
 import { dirname, join, relative } from 'path';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { flattenArray } from '../../containers/flatten';
 import {
   checkoutPathspec,
@@ -64,7 +64,7 @@ export const createMetafile = createAppAsyncThunk<
   const filetype = await thunkAPI.dispatch(fetchFiletype(input.path ?? '')).unwrap();
   return thunkAPI.dispatch(
     metafileAdded({
-      id: v4(),
+      id: randomUUID(),
       name: input.metafile ? input.metafile.name : extractFilename(input.path),
       modified: DateTime.local().valueOf(),
       handler: input.metafile?.handler ?? filetype?.handler ?? 'Editor',
@@ -114,7 +114,7 @@ export const updateFileMetafile = createAppAsyncThunk<FileMetafile, FilebasedMet
   async (metafile, thunkAPI) => {
     const mtime = await hasFilebasedUpdates(metafile);
     if (!isDefined(mtime)) return metafile as FileMetafile;
-    const content = await readFileAsync(metafile.path, { encoding: 'utf-8' });
+    const content = (await readFileAsync(metafile.path, { encoding: 'utf-8' })).toString();
     return hasUpdates(metafile, { content })
       ? (thunkAPI.dispatch(
           metafileUpdated({

--- a/src/store/thunks/repos.ts
+++ b/src/store/thunks/repos.ts
@@ -1,7 +1,15 @@
 import { PathLike } from 'fs-extra';
 import parsePath from 'parse-path';
-import { v4 } from 'uuid';
-import { extractFromURL, extractRepoName, getConfig, getWorktreePaths, GitConfig, revParse, worktreePrune } from '../../containers/git';
+import { randomUUID } from 'crypto';
+import {
+  extractFromURL,
+  extractRepoName,
+  getConfig,
+  getWorktreePaths,
+  GitConfig,
+  revParse,
+  worktreePrune
+} from '../../containers/git';
 import { extractFilename } from '../../containers/io';
 import { ExactlyOne } from '../../containers/utils';
 import { createAppAsyncThunk } from '../hooks';
@@ -11,71 +19,95 @@ import { repoAdded, Repository } from '../slices/repos';
 import { fetchBranches } from './branches';
 import { fetchParentMetafile } from './metafiles';
 
-export const fetchRepo = createAppAsyncThunk<Repository | undefined, ExactlyOne<{ filepath: PathLike, metafile: FilebasedMetafile }>>(
-    'repos/fetchRepo',
-    async (input, thunkAPI) => {
-        const state = thunkAPI.getState();
+export const fetchRepo = createAppAsyncThunk<
+  Repository | undefined,
+  ExactlyOne<{ filepath: PathLike; metafile: FilebasedMetafile }>
+>('repos/fetchRepo', async (input, thunkAPI) => {
+  const state = thunkAPI.getState();
 
-        if (input.metafile) {
-            // if metafile already has a repo UUID, check for matching repository
-            let repo = input.metafile.repo ? repoSelectors.selectById(state, input.metafile.repo) : undefined;
-            // otherwise if parent metafile already has a repo UUID, check for matching repository
-            const parent = !repo ? await thunkAPI.dispatch(fetchParentMetafile(input.metafile)).unwrap() : undefined;
-            repo = (parent && isVersionedMetafile(parent)) ? repoSelectors.selectById(state, parent.repo) : repo;
-            if (repo) return repo;
-        }
-        // unless filepath has a root path, there is no repository
-        const filepath: PathLike = input.metafile ? input.metafile.path : input.filepath;
-        const { dir, worktreeDir } = await getWorktreePaths(filepath);
-        if (!dir) return undefined;
+  if (input.metafile) {
+    // if metafile already has a repo UUID, check for matching repository
+    let repo = input.metafile.repo
+      ? repoSelectors.selectById(state, input.metafile.repo)
+      : undefined;
+    // otherwise if parent metafile already has a repo UUID, check for matching repository
+    const parent = !repo
+      ? await thunkAPI.dispatch(fetchParentMetafile(input.metafile)).unwrap()
+      : undefined;
+    repo =
+      parent && isVersionedMetafile(parent) ? repoSelectors.selectById(state, parent.repo) : repo;
+    if (repo) return repo;
+  }
+  // unless filepath has a root path, there is no repository
+  const filepath: PathLike = input.metafile ? input.metafile.path : input.filepath;
+  const { dir, worktreeDir } = await getWorktreePaths(filepath);
+  if (!dir) return undefined;
 
-        // check root for existing repository
-        const root = worktreeDir ? worktreeDir : dir;
-        const existingRepo = repoSelectors.selectByRoot(state, root);
-        const repo = existingRepo ? existingRepo : await thunkAPI.dispatch(buildRepo(root)).unwrap();
-        return repo;
-    }
-)
+  // check root for existing repository
+  const root = worktreeDir ? worktreeDir : dir;
+  const existingRepo = repoSelectors.selectByRoot(state, root);
+  const repo = existingRepo ? existingRepo : await thunkAPI.dispatch(buildRepo(root)).unwrap();
+  return repo;
+});
 
 export const buildRepo = createAppAsyncThunk<Repository, PathLike>(
-    'repos/buildRepo',
-    async (filepath, thunkAPI) => {
-        const { dir } = await getWorktreePaths(filepath);
-        const { url, oauth } = await getRemoteConfig(dir);
-        if (dir) await worktreePrune({ dir: dir, verbose: true }); // prune worktree information to remove stale linked branches
-        const current = dir ? await revParse({ dir: dir, options: ['abbrevRef'], args: 'HEAD' }) : undefined;
-        const branches = dir ? await thunkAPI.dispatch(fetchBranches(dir)).unwrap() : { local: [], remote: [] };
-        const { local, remote } = { local: branches.local.map(branch => branch.id), remote: branches.remote.map(branch => branch.id) };
-        const { username, password } = await getCredentials(dir);
-        return thunkAPI.dispatch(repoAdded({
-            id: v4(),
-            name: url ? extractRepoName(url.href) : (dir ? extractFilename(dir) : ''),
-            root: dir ? dir : '',
-            corsProxy: 'https://cors-anywhere.herokuapp.com',
-            url: url ? url.href : '',
-            default: current ?? '',
-            local: local,
-            remote: remote,
-            oauth: oauth ? oauth : 'github',
-            username: username,
-            password: password,
-            token: ''
+  'repos/buildRepo',
+  async (filepath, thunkAPI) => {
+    const { dir } = await getWorktreePaths(filepath);
+    const { url, oauth } = await getRemoteConfig(dir);
+    if (dir) await worktreePrune({ dir: dir, verbose: true }); // prune worktree information to remove stale linked branches
+    const current = dir
+      ? await revParse({ dir: dir, options: ['abbrevRef'], args: 'HEAD' })
+      : undefined;
+    const branches = dir
+      ? await thunkAPI.dispatch(fetchBranches(dir)).unwrap()
+      : { local: [], remote: [] };
+    const { local, remote } = {
+      local: branches.local.map(branch => branch.id),
+      remote: branches.remote.map(branch => branch.id)
+    };
+    const { username, password } = await getCredentials(dir);
+    return thunkAPI.dispatch(
+      repoAdded({
+        id: randomUUID(),
+        name: url ? extractRepoName(url.href) : dir ? extractFilename(dir) : '',
+        root: dir ? dir : '',
+        corsProxy: 'https://cors-anywhere.herokuapp.com',
+        url: url ? url.href : '',
+        default: current ?? '',
+        local: local,
+        remote: remote,
+        oauth: oauth ? oauth : 'github',
+        username: username,
+        password: password,
+        token: ''
+      })
+    ).payload;
+  }
+);
 
-        })).payload;
-    }
-)
-
-const getRemoteConfig = async (dir: PathLike | undefined)
-    : Promise<{ url: parsePath.ParsedPath | undefined; oauth: Repository['oauth'] | undefined }> => {
-    const remoteConfig: GitConfig = dir ? await getConfig({ dir: dir, keyPath: 'remote.origin.url' }) : { scope: 'none' };
-    return (remoteConfig.scope !== 'none') ? extractFromURL(remoteConfig.value) : { url: undefined, oauth: undefined };
+const getRemoteConfig = async (
+  dir: PathLike | undefined
+): Promise<{ url: parsePath.ParsedPath | undefined; oauth: Repository['oauth'] | undefined }> => {
+  const remoteConfig: GitConfig = dir
+    ? await getConfig({ dir: dir, keyPath: 'remote.origin.url' })
+    : { scope: 'none' };
+  return remoteConfig.scope !== 'none'
+    ? extractFromURL(remoteConfig.value)
+    : { url: undefined, oauth: undefined };
 };
 
-const getCredentials = async (dir: PathLike | undefined): Promise<{ username: string; password: string }> => {
-    const usernameConfig: GitConfig = dir ? await getConfig({ dir: dir, keyPath: 'user.name' }) : { scope: 'none' };
-    const passwordConfig: GitConfig = dir ? await getConfig({ dir: dir, keyPath: 'credential.helper' }) : { scope: 'none' };
-    return {
-        username: usernameConfig.scope === 'none' ? '' : usernameConfig.value,
-        password: passwordConfig.scope === 'none' ? '' : passwordConfig.value
-    };
+const getCredentials = async (
+  dir: PathLike | undefined
+): Promise<{ username: string; password: string }> => {
+  const usernameConfig: GitConfig = dir
+    ? await getConfig({ dir: dir, keyPath: 'user.name' })
+    : { scope: 'none' };
+  const passwordConfig: GitConfig = dir
+    ? await getConfig({ dir: dir, keyPath: 'credential.helper' })
+    : { scope: 'none' };
+  return {
+    username: usernameConfig.scope === 'none' ? '' : usernameConfig.value,
+    password: passwordConfig.scope === 'none' ? '' : passwordConfig.value
+  };
 };

--- a/src/store/thunks/stacks.ts
+++ b/src/store/thunks/stacks.ts
@@ -1,6 +1,6 @@
 import { XYCoord } from 'react-dnd';
 import { DateTime } from 'luxon';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { Stack, stackAdded, stackRemoved, stackUpdated } from '../slices/stacks';
 import { cardUpdated } from '../slices/cards';
 import { UUID } from '../types';
@@ -8,91 +8,124 @@ import { createAppAsyncThunk } from '../hooks';
 import cardSelectors from '../selectors/cards';
 import stackSelectors from '../selectors/stacks';
 
-export const createStack = createAppAsyncThunk<Stack, { name: string, note: string, cards: UUID[] }>(
-    'stacks/createStack',
-    async (input, thunkAPI) => {
-        const cards = cardSelectors.selectByIds(thunkAPI.getState(), input.cards);
+export const createStack = createAppAsyncThunk<
+  Stack,
+  { name: string; note: string; cards: UUID[] }
+>('stacks/createStack', async (input, thunkAPI) => {
+  const cards = cardSelectors.selectByIds(thunkAPI.getState(), input.cards);
 
-        const newStack = thunkAPI.dispatch(stackAdded({
-            id: v4(),
-            name: input.name,
-            created: DateTime.local().valueOf(),
-            modified: DateTime.local().valueOf(),
-            note: input.note,
-            cards: input.cards,
-            left: cards[0] ? cards[0].left : 0,
-            top: cards[0] ? cards[0].top : 0
-        })).payload;
-        cards.map((card, index) => thunkAPI.dispatch(cardUpdated({
-            ...card, captured: newStack.id, zIndex: index + 1, top: (10 * index + 50), left: (10 * index + 10)
-        })));
-        return newStack;
-    }
-);
+  const newStack = thunkAPI.dispatch(
+    stackAdded({
+      id: randomUUID(),
+      name: input.name,
+      created: DateTime.local().valueOf(),
+      modified: DateTime.local().valueOf(),
+      note: input.note,
+      cards: input.cards,
+      left: cards[0] ? cards[0].left : 0,
+      top: cards[0] ? cards[0].top : 0
+    })
+  ).payload;
+  cards.map((card, index) =>
+    thunkAPI.dispatch(
+      cardUpdated({
+        ...card,
+        captured: newStack.id,
+        zIndex: index + 1,
+        top: 10 * index + 50,
+        left: 10 * index + 10
+      })
+    )
+  );
+  return newStack;
+});
 
 /** Add cards to an existing Stack object. */
-export const pushCards = createAppAsyncThunk<void, { stack: UUID, cards: UUID[] }>(
-    'stacks/pushCards',
-    async (input, thunkAPI) => {
-        const state = thunkAPI.getState();
-        const stack = stackSelectors.selectById(state, input.stack);
-        const cards = cardSelectors.selectByIds(state, input.cards);
-        if (stack && cards.length > 0) {
-            const updated = thunkAPI.dispatch(stackUpdated({
-                ...stack,
-                cards: [...stack.cards, ...input.cards]
-            })).payload;
+export const pushCards = createAppAsyncThunk<void, { stack: UUID; cards: UUID[] }>(
+  'stacks/pushCards',
+  async (input, thunkAPI) => {
+    const state = thunkAPI.getState();
+    const stack = stackSelectors.selectById(state, input.stack);
+    const cards = cardSelectors.selectByIds(state, input.cards);
+    if (stack && cards.length > 0) {
+      const updated = thunkAPI.dispatch(
+        stackUpdated({
+          ...stack,
+          cards: [...stack.cards, ...input.cards]
+        })
+      ).payload;
 
-            // filter out any cards that are already captured by the stack
-            cards.filter(c => c.captured !== input.stack).map((card, index) => {
-                thunkAPI.dispatch(cardUpdated({
-                    ...card,
-                    captured: updated.id,
-                    zIndex: updated.cards.length + (index + 1),
-                    top: (10 * (updated.cards.length + index) + 50),
-                    left: (10 * (updated.cards.length + index) + 10)
-                }))
-            }
-            );
-        }
+      // filter out any cards that are already captured by the stack
+      cards
+        .filter(c => c.captured !== input.stack)
+        .map((card, index) => {
+          thunkAPI.dispatch(
+            cardUpdated({
+              ...card,
+              captured: updated.id,
+              zIndex: updated.cards.length + (index + 1),
+              top: 10 * (updated.cards.length + index) + 50,
+              left: 10 * (updated.cards.length + index) + 10
+            })
+          );
+        });
     }
+  }
 );
 
-/** 
- * Remove cards from an existing Stack object. Positioning of the card becomes relative to the bounds of the canvas, unless no `delta` 
+/**
+ * Remove cards from an existing Stack object. Positioning of the card becomes relative to the bounds of the canvas, unless no `delta`
  * parameter is provide (in which case the card is arbitrarily positioned outside of the stack). If the `delta` parameter used, then the
- * `{x,y}` values can be gathered from `DropTargetMonitor.getDifferenceFromInitialOffset()`. 
+ * `{x,y}` values can be gathered from `DropTargetMonitor.getDifferenceFromInitialOffset()`.
  */
-export const popCards = createAppAsyncThunk<void, { cards: UUID[], delta?: XYCoord }>(
-    'stacks/pushCards',
-    async (input, thunkAPI) => {
-        const state = thunkAPI.getState();
-        const removingCards = cardSelectors.selectByIds(state, input.cards);
-        const stack = stackSelectors.selectById(state, removingCards[0]?.captured ? removingCards[0].captured : '');
-        if (stack) {
-            // update the cards targetted for removal
-            removingCards.map(card => thunkAPI.dispatch(cardUpdated({
-                ...card,
-                captured: undefined,
-                zIndex: 1,
-                left: input.delta ? (stack.left + card.left + input.delta.x) : stack.left + card.left + 25,
-                top: input.delta ? (stack.top + card.top + input.delta.y) : stack.top + card.top + 25
-            })));
-            // update the stack
-            const remainingCards = cardSelectors.selectByIds(state, stack.cards.filter(id => !input.cards.some(c => c === id)));
-            const updated = thunkAPI.dispatch(stackUpdated({
-                ...stack,
-                cards: remainingCards.map(c => c.id)
-            })).payload;
-            // update the other cards in the stack
-            remainingCards.map((card, index) => thunkAPI.dispatch(cardUpdated({
-                ...card,
-                captured: updated.cards.length < 2 ? undefined : card.captured,
-                zIndex: updated.cards.length < 2 ? 1 : index,
-                left: updated.cards.length < 2 ? (updated.left + card.left + 25) : (10 * index + 10),
-                top: updated.cards.length < 2 ? (updated.top + card.top + 25) : (10 * index + 50)
-            })));
-            if (updated.cards.length < 2) thunkAPI.dispatch(stackRemoved(updated.id));
-        }
+export const popCards = createAppAsyncThunk<void, { cards: UUID[]; delta?: XYCoord }>(
+  'stacks/pushCards',
+  async (input, thunkAPI) => {
+    const state = thunkAPI.getState();
+    const removingCards = cardSelectors.selectByIds(state, input.cards);
+    const stack = stackSelectors.selectById(
+      state,
+      removingCards[0]?.captured ? removingCards[0].captured : ''
+    );
+    if (stack) {
+      // update the cards targetted for removal
+      removingCards.map(card =>
+        thunkAPI.dispatch(
+          cardUpdated({
+            ...card,
+            captured: undefined,
+            zIndex: 1,
+            left: input.delta
+              ? stack.left + card.left + input.delta.x
+              : stack.left + card.left + 25,
+            top: input.delta ? stack.top + card.top + input.delta.y : stack.top + card.top + 25
+          })
+        )
+      );
+      // update the stack
+      const remainingCards = cardSelectors.selectByIds(
+        state,
+        stack.cards.filter(id => !input.cards.some(c => c === id))
+      );
+      const updated = thunkAPI.dispatch(
+        stackUpdated({
+          ...stack,
+          cards: remainingCards.map(c => c.id)
+        })
+      ).payload;
+      // update the other cards in the stack
+      remainingCards.map((card, index) =>
+        thunkAPI.dispatch(
+          cardUpdated({
+            ...card,
+            captured: updated.cards.length < 2 ? undefined : card.captured,
+            zIndex: updated.cards.length < 2 ? 1 : index,
+            left: updated.cards.length < 2 ? updated.left + card.left + 25 : 10 * index + 10,
+            top: updated.cards.length < 2 ? updated.top + card.top + 25 : 10 * index + 50
+          })
+        )
+      );
+      if (updated.cards.length < 2) thunkAPI.dispatch(stackRemoved(updated.id));
     }
+  }
 );

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,30 +5,30 @@
 
 import { DateTime } from 'luxon';
 // import { PathLike } from 'fs-extra';
-import { v4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import sha1 from 'sha1';
 
 /** Universal unique identifier based on RFC4122 version 4 for cryptographically-strong random values. */
-export type UUID = ReturnType<typeof v4>;
+export type UUID = ReturnType<typeof randomUUID>;
 /** 160-bit hash value for identify revisions in Git and other VCS. */
 export type SHA1 = ReturnType<typeof sha1>;
 /** Epoch millisecond representation of a valid DateTime value. */
 export type Timestamp = ReturnType<DateTime['valueOf']>;
 /** Detailed commit representation for Git. */
 export type CommitObject = {
-    oid: string;
-    message: string;
-    parents: string[];
-    author: {
-        name: string;
-        email: string;
-        timestamp: Timestamp | undefined;
-    };
-    committer?: {
-        name: string;
-        email: string;
-        timestamp: Timestamp | undefined;
-    };
+  oid: string;
+  message: string;
+  parents: string[];
+  author: {
+    name: string;
+    email: string;
+    timestamp: Timestamp | undefined;
+  };
+  committer?: {
+    name: string;
+    email: string;
+    timestamp: Timestamp | undefined;
+  };
 };
 /**
  * | status                | description                                                                            |
@@ -48,8 +48,21 @@ export type CommitObject = {
  * | `"*undeletemodified"` | file was deleted from the index, but is present with modifications in the working dir  |
  * | `"unmerged"`          | file has unmerged changes from an incomplete merge                                     |
  */
-export type GitStatus = 'modified' | 'ignored' | 'unmodified' | '*modified' | '*deleted' | '*added'
-    | 'absent' | 'deleted' | 'added' | '*unmodified' | '*absent' | '*undeleted' | '*undeletemodified' | 'unmerged';
+export type GitStatus =
+  | 'modified'
+  | 'ignored'
+  | 'unmodified'
+  | '*modified'
+  | '*deleted'
+  | '*added'
+  | 'absent'
+  | 'deleted'
+  | 'added'
+  | '*unmodified'
+  | '*absent'
+  | '*undeleted'
+  | '*undeletemodified'
+  | 'unmerged';
 /**
  * | status                | description                                                                            |
  * | --------------------- | -------------------------------------------------------------------------------------- |
@@ -66,7 +79,27 @@ export type BranchStatus = 'clean' | 'uncommitted' | 'unmerged';
  * | `"unlinked"`          | no file linked to metafile, virtual metafile                                           |
  */
 export type FilesystemStatus = 'modified' | 'unmodified' | 'unlinked';
-export type CardType = 'Loading' | 'Editor' | 'Diff' | 'Explorer' | 'Browser' | 'Branches' | 'Merge' | 'SourceControl';
-export type ModalType = 'BranchList' | 'CloneSelector' | 'DiffPicker' | 'Error' | 'GitGraph' | 'MergeSelector' | 'NewBranchDialog' | 'NewCardDialog' |
-    'SourcePicker' | 'CommitDialog' | 'Notification' | 'GitExplorer' | 'DirectExplorer';
+export type CardType =
+  | 'Loading'
+  | 'Editor'
+  | 'Diff'
+  | 'Explorer'
+  | 'Browser'
+  | 'Branches'
+  | 'Merge'
+  | 'SourceControl';
+export type ModalType =
+  | 'BranchList'
+  | 'CloneSelector'
+  | 'DiffPicker'
+  | 'Error'
+  | 'GitGraph'
+  | 'MergeSelector'
+  | 'NewBranchDialog'
+  | 'NewCardDialog'
+  | 'SourcePicker'
+  | 'CommitDialog'
+  | 'Notification'
+  | 'GitExplorer'
+  | 'DirectExplorer';
 export type Flag = 'checkout' | 'updating';

--- a/src/test-utils/mock-git.ts
+++ b/src/test-utils/mock-git.ts
@@ -1,4 +1,3 @@
-
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as git from 'isomorphic-git';
@@ -12,7 +11,7 @@ import { Either } from '../containers/utils';
  * Accept some meta-information about the repository, and then a path to an existing .git directory
  * in order to create a consolidated packfile version of the git repository, which can be unpacked
  * for use as a mocked git repository inside of a mock-fs-promise instance.
- * 
+ *
  * Design principles for this Git repository mocking library (extending from `mock-fs-promise`):
  *   (1) Create fully functional local Git repositories
  *   (2) Deterministic repositories for simplified testing
@@ -26,209 +25,223 @@ type SHA1 = ReturnType<typeof sha1>;
 type IncludeOrExcludeList = Either<{ include: fs.PathLike[] }, { exclude: fs.PathLike[] }>;
 
 export type MockInstanceEnhanced = MockInstance & {
-    getRepoRoot(): string;
-    getCommits(): SHA1[];
-    stage(filepath: fs.PathLike): Promise<void>;
-    commit(commit: MockedCommit): Promise<string>;
-}
+  getRepoRoot(): string;
+  getCommits(): SHA1[];
+  stage(filepath: fs.PathLike): Promise<void>;
+  commit(commit: MockedCommit): Promise<string>;
+};
 
 type MockedCommit = {
-    oid: SHA1,
-    message: string,
-    author: Partial<{
-        name: string,
-        email: string,
-        timestamp: number,
-        timezoneOffset: number
-    }>,
-    committer: Partial<{
-        name: string,
-        email: string,
-        timestamp: number,
-        timezoneOffset: number
-    }>,
-    files: 'all' | IncludeOrExcludeList
-}
+  oid: SHA1;
+  message: string;
+  author: Partial<{
+    name: string;
+    email: string;
+    timestamp: number;
+    timezoneOffset: number;
+  }>;
+  committer: Partial<{
+    name: string;
+    email: string;
+    timestamp: number;
+    timezoneOffset: number;
+  }>;
+  files: 'all' | IncludeOrExcludeList;
+};
 
 type MockedBranch = {
-    name: string,
-    base: string,
-    ahead: MockedCommit[],
-    behind?: number
-}
+  name: string;
+  base: string;
+  ahead: MockedCommit[];
+  behind?: number;
+};
 
 export type MockedRepository = {
-    config?: Partial<{
-        'user.name': string,
-        'user.email': string
-    }>,
-    url?: string,
-    default: string,
-    branches: MockedBranch[]
-}
+  config?: Partial<{
+    'user.name': string;
+    'user.email': string;
+  }>;
+  url?: string;
+  default: string;
+  branches: MockedBranch[];
+};
 
-export const mockGit = async (instance: MockInstance, repo: MockedRepository): Promise<MockInstanceEnhanced> => {
-    const dir = instance.getRoot();
-    const gitdir = path.resolve(dir, '.git');
-    const commits: SHA1[] = [];
+export const mockGit = async (
+  instance: MockInstance,
+  repo: MockedRepository
+): Promise<MockInstanceEnhanced> => {
+  const dir = instance.getRoot();
+  const gitdir = path.resolve(dir, '.git');
+  const commits: SHA1[] = [];
 
-    // check if a git repository already exists
-    if (!(await fs.pathExists(gitdir))) {
-        await git.init({ fs, dir, defaultBranch: repo.default });
-        if (repo.config) {
-            await git.setConfig({
-                fs,
-                dir,
-                path: 'user.name',
-                value: repo.config['user.name'] ? repo.config['user.name'] : casual.full_name
-            });
-            await git.setConfig({
-                fs,
-                dir,
-                path: 'user.email',
-                value: repo.config['user.email'] ? repo.config['user.email'] : casual.email
-            });
-        }
-        if (repo.url) {
-            await git.addRemote({
-                fs,
-                dir,
-                remote: 'origin',
-                url: repo.url
-            })
-        }
-        for (const branch of repo.branches) {
-            const newCommits = await writeBranch(dir, branch);
-            newCommits.map(commit => commits.push(commit));
-        }
+  // check if a git repository already exists
+  if (!(await fs.pathExists(gitdir))) {
+    await git.init({ fs, dir, defaultBranch: repo.default });
+    if (repo.config) {
+      await git.setConfig({
+        fs,
+        dir,
+        path: 'user.name',
+        value: repo.config['user.name'] ? repo.config['user.name'] : casual.full_name
+      });
+      await git.setConfig({
+        fs,
+        dir,
+        path: 'user.email',
+        value: repo.config['user.email'] ? repo.config['user.email'] : casual.email
+      });
     }
-
-    const stage = (filepath: fs.PathLike): Promise<void> => {
-        return git.add({
-            fs,
-            dir: dir,
-            filepath: filepath.toString()
-        });
+    if (repo.url) {
+      await git.addRemote({
+        fs,
+        dir,
+        remote: 'origin',
+        url: repo.url
+      });
     }
-
-    const commit = (commit: MockedCommit): Promise<string> => {
-        return git.commit({
-            fs,
-            dir,
-            message: commit.message,
-            author: commit.author,
-            committer: commit.author
-        });
+    for (const branch of repo.branches) {
+      const newCommits = await writeBranch(dir, branch);
+      newCommits.map(commit => commits.push(commit));
     }
+  }
 
-    return {
-        ...instance,
-        getRepoRoot: () => gitdir,
-        getCommits: () => commits,
-        stage,
-        commit
-    };
-}
+  const stage = (filepath: fs.PathLike): Promise<void> => {
+    return git.add({
+      fs,
+      dir: dir,
+      filepath: filepath.toString()
+    });
+  };
+
+  const commit = (commit: MockedCommit): Promise<string> => {
+    return git.commit({
+      fs,
+      dir,
+      message: commit.message,
+      author: commit.author,
+      committer: commit.author
+    });
+  };
+
+  return {
+    ...instance,
+    getRepoRoot: () => gitdir,
+    getCommits: () => commits,
+    stage,
+    commit
+  };
+};
 
 const gitAddMany = async (dir: fs.PathLike, files: fs.PathLike[]) =>
-    Promise.all(files.map(file => git.add({
+  Promise.all(
+    files.map(file =>
+      git.add({
         fs,
         dir: dir.toString(),
         filepath: file.toString()
-    })));
+      })
+    )
+  );
 
 const writeBranch = async (dir: string, branch: MockedBranch): Promise<SHA1[]> => {
-    const commits: SHA1[] = [];
+  const commits: SHA1[] = [];
 
-    // checkout the base branch into the working tree, if needed
-    if ((await git.listBranches({ fs, dir })).length > 0) await git.checkout({
-        fs,
-        dir,
-        ref: branch.base,
+  // checkout the base branch into the working tree, if needed
+  if ((await git.listBranches({ fs, dir })).length > 0)
+    await git.checkout({
+      fs,
+      dir,
+      ref: branch.base
     });
-    // branch off to the new branch
-    await git.branch({
-        fs,
-        dir,
-        ref: branch.name
-    });
-    // reset HEAD to point to previous commits, if needed
-    if (branch.behind) {
-        await gitReset(dir, `HEAD~${branch.behind}`, branch.name, true);
+  // branch off to the new branch
+  await git.branch({
+    fs,
+    dir,
+    ref: branch.name
+  });
+  // reset HEAD to point to previous commits, if needed
+  if (branch.behind) {
+    await gitReset(dir, `HEAD~${branch.behind}`, branch.name, true);
+  }
+
+  // add all branch-specific commits
+  for (const [index, commit] of branch.ahead.entries()) {
+    const allFiles = (await readDirAsyncDepth(dir))
+      .map(file => path.relative(dir, file))
+      .filter(filepath => filepath.length > 0);
+
+    if (commit.files === 'all') {
+      if (index > 0) await randomFileUpdate(allFiles);
+      await gitAddMany(dir, allFiles);
+    } else if (commit.files.include) {
+      if (index > 0) await randomFileUpdate(commit.files.include);
+      await gitAddMany(dir, commit.files.include);
+    } else if (commit.files.exclude) {
+      const stringifiedExcludes = commit.files.exclude.map(file => file.toString());
+      const includedFiles = allFiles.filter(file => !stringifiedExcludes.includes(file));
+      if (index > 0) await randomFileUpdate(includedFiles);
+      await gitAddMany(dir, includedFiles);
     }
 
-    // add all branch-specific commits
-    for (const [index, commit] of branch.ahead.entries()) {
-        const allFiles = (await readDirAsyncDepth(dir)).map(file => path.relative(dir, file)).filter(filepath => filepath.length > 0);
-
-        if (commit.files === 'all') {
-            if (index > 0) await randomFileUpdate(allFiles);
-            await gitAddMany(dir, allFiles);
-        } else if (commit.files.include) {
-            if (index > 0) await randomFileUpdate(commit.files.include);
-            await gitAddMany(dir, commit.files.include);
-        } else if (commit.files.exclude) {
-            const stringifiedExcludes = commit.files.exclude.map(file => file.toString());
-            const includedFiles = allFiles.filter(file => !stringifiedExcludes.includes(file));
-            if (index > 0) await randomFileUpdate(includedFiles);
-            await gitAddMany(dir, includedFiles);
-        }
-
-        commits.push(await git.commit({
-            fs,
-            dir,
-            message: commit.message,
-            author: commit.author,
-            committer: commit.committer
-        }));
-    }
-    return commits;
-}
+    commits.push(
+      await git.commit({
+        fs,
+        dir,
+        message: commit.message,
+        author: commit.author,
+        committer: commit.committer
+      })
+    );
+  }
+  return commits;
+};
 
 // Copied from `jcubic`: https://github.com/jcubic/git/blob/gh-pages/js/main.js#L1915
 // Same as `git reset --soft` or `git reset --hard` for moving back the current HEAD pointer
 // on a git branch.
 const gitReset = async (dir: string, ref: string, branch: string, hard = false) => {
-    const re = /^HEAD~([0-9]+)$/;
-    const match = ref.match(re);
-    if (match) {
-        const count = +(match[1] as string);
-        const commits = await git.log({ dir, fs, depth: count + 1 });
-        return new Promise<void>((resolve, reject) => {
-            if (commits.length < count + 1) {
-                return reject('Not enough commits');
+  const re = /^HEAD~([0-9]+)$/;
+  const match = ref.match(re);
+  if (match) {
+    const count = +(match[1] as string);
+    const commits = await git.log({ dir, fs, depth: count + 1 });
+    return new Promise<void>((resolve, reject) => {
+      if (commits.length < count + 1) {
+        return reject('Not enough commits');
+      }
+      const commit = commits.pop()?.oid;
+      fs.writeFile(`${dir}/.git/refs/heads/${branch}`, commit + '\n', err => {
+        if (err) {
+          return reject(err);
+        }
+        if (!hard) {
+          resolve();
+        } else {
+          // clear the index (if any)
+          fs.unlink(`${dir}/.git/index`, err => {
+            if (err) {
+              return reject(err);
             }
-            const commit = commits.pop()?.oid;
-            fs.writeFile(`${dir}/.git/refs/heads/${branch}`, commit + '\n', (err) => {
-                if (err) {
-                    return reject(err);
-                }
-                if (!hard) {
-                    resolve();
-                } else {
-                    // clear the index (if any)
-                    fs.unlink(`${dir}/.git/index`, (err) => {
-                        if (err) {
-                            return reject(err);
-                        }
-                        // checkout the branch into the working tree
-                        git.checkout({ fs, dir, ref: branch }).then(resolve);
-                    })
-                }
-            })
-        })
-    }
-    return Promise.reject(`Wrong ref ${ref}`);
-}
+            // checkout the branch into the working tree
+            git.checkout({ fs, dir, ref: branch }).then(resolve);
+          });
+        }
+      });
+    });
+  }
+  return Promise.reject(`Wrong ref ${ref}`);
+};
 
 // given a set of filepaths, either targeted or randomly select file and update with additional content
-const randomFileUpdate = async (filepaths: fs.PathLike[], index = getRandomInt(filepaths.length)) => {
-    const randomSelection = filepaths[index] as fs.PathLike;
-    const filepath = path.resolve(randomSelection.toString());
-    const fileContent = await readFileAsync(filepath, { encoding: 'utf-8' });
-    await writeFileAsync(filepath, fileContent + casual.text);
-}
+const randomFileUpdate = async (
+  filepaths: fs.PathLike[],
+  index = getRandomInt(filepaths.length)
+) => {
+  const randomSelection = filepaths[index] as fs.PathLike;
+  const filepath = path.resolve(randomSelection.toString());
+  const fileContent = (await readFileAsync(filepath, { encoding: 'utf-8' })).toString();
+  await writeFileAsync(filepath, fileContent + casual.text);
+};
 
-const getRandomInt = (max: number, min = 1) => Math.max(
-    Math.floor(Math.random() * Math.floor(max)), min
-);
+const getRandomInt = (max: number, min = 1) =>
+  Math.max(Math.floor(Math.random() * Math.floor(max)), min);

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@
     "@babel/helper-simple-access" "^7.18.6"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.18.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
@@ -1976,11 +1976,6 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
-"@types/uuid@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
-  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
-
 "@types/valid-url@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.3.tgz#a124389fb953559c7f889795a98620e91adb3687"
@@ -2050,14 +2045,6 @@
     "@typescript-eslint/typescript-estree" "5.57.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.47.1":
-  version "5.47.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz#0d302b3c2f20ab24e4787bf3f5a0d8c449b823bd"
-  integrity sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==
-  dependencies:
-    "@typescript-eslint/types" "5.47.1"
-    "@typescript-eslint/visitor-keys" "5.47.1"
-
 "@typescript-eslint/scope-manager@5.57.0":
   version "5.57.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz#79ccd3fa7bde0758059172d44239e871e087ea36"
@@ -2076,28 +2063,10 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.47.1":
-  version "5.47.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.47.1.tgz#459f07428aec5a8c4113706293c2ae876741ac8e"
-  integrity sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==
-
 "@typescript-eslint/types@5.57.0":
   version "5.57.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.0.tgz#727bfa2b64c73a4376264379cf1f447998eaa132"
   integrity sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==
-
-"@typescript-eslint/typescript-estree@5.47.1":
-  version "5.47.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz#b9d8441308aca53df7f69b2c67a887b82c9ed418"
-  integrity sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==
-  dependencies:
-    "@typescript-eslint/types" "5.47.1"
-    "@typescript-eslint/visitor-keys" "5.47.1"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.57.0":
   version "5.57.0"
@@ -2125,14 +2094,6 @@
     "@typescript-eslint/typescript-estree" "5.57.0"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
-
-"@typescript-eslint/visitor-keys@5.47.1":
-  version "5.47.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz#d35c2da544dbb685db9c5b5b85adac0a1d74d1f2"
-  integrity sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==
-  dependencies:
-    "@typescript-eslint/types" "5.47.1"
-    eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.57.0":
   version "5.57.0"
@@ -4242,18 +4203,6 @@ eslint-scope@^7.1.1:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.0:
   version "3.4.0"
@@ -8170,11 +8119,6 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
-regexpp@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
-
 relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
@@ -9414,11 +9358,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Entities stored in the Redux store are currently uniquely identified using the [`uuidjs/uuid`](https://github.com/uuidjs/uuid) library, but this dependency can be entirely removed in favor of the built-in JavaScript [`Crypto`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) library. Removing separate libraries in favor of built-ins reduces the package size, attack surface, and robustness of Synectic.

This PR resolves #1116.

### **Changes**:

This PR makes the following changes:
* Replaces all instances of [`uuid.v4()`](https://github.com/uuidjs/uuid#uuidv4options-buffer-offset) with [`crypto.randomUUID()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)
* Removes [`uuid`](https://github.com/uuidjs/uuid) dependency from [`package.json`](https://github.com/EPICLab/synectic/blob/737c9d7cbb5eb1b3997bf1487bc931cd886a8772/package.json#L142)
* Updates [`readFileAsync`](https://github.com/EPICLab/synectic/blob/737c9d7cbb5eb1b3997bf1487bc931cd886a8772/src/containers/io.ts#L176-L223) calls to convert `Promise<string | Buffer>` returned values into `string` (after awaiting) in order to match update [`fs.readFile`](https://nodejs.org/api/fs.html#filehandlereadfileoptions) return types as defined in [`@types/fs-extra`](https://www.npmjs.com/package/@types/fs-extra), per:
   * #1096
