### PR TITLE
Deploy GitHub Actions workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,11 +17,9 @@ jobs:
       - name: Halt on workflow_dispatch trigger
         run: |
           echo The workflow was manually triggered, so no version bump will be pushed.
-  build:
-    uses: ./.github/workflows/build.yml
   bump-version:
     name: 'Bump version on main branch'
-    needs: [build]
+    needs: [if_manual]
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,10 @@ on:
         type: string
 jobs:
   build:
+    name: Build Check
     uses: ./.github/workflows/build.yml
   bump:
+    name: Bump Version
     uses: ./.github/workflows/bump.yml
   deploy:
     needs: [build, bump]


### PR DESCRIPTION
Restructured the GitHub Actions workflows only the [Deploy to GitHub Pages](.github/workflows/deploy.yml) workflow depends on the other workflows.


so that [Bump Version](.github/workflows/bump.yml) runs independent of the other workflows, and [Deploy to GitHub Pages](.github/workflows/deploy.yml) is dependent on both [Build Check](.github/workflows/build.yml) and [Bump Version](.github/workflows/bump.yml) in order to guarantee a successful build and accurate version number prior to deploying site updates.

### **Changes**:

This PR makes the following changes:
* [Deploy to GitHub Pages](.github/workflows/deploy.yml) depends on [Build Check](.github/workflows/build.yml) and [Bump Version](.github/workflows/bump.yml) prior to deploying site updates
* [Bump Version](.github/workflows/bump.yml) no longer depends on [Build Check](.github/workflows/build.yml) (prevents redundant calls to `Build Check` when deploying)

