### PR TITLE
Refinement on GitHub Actions workflows

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,11 +17,9 @@ jobs:
       - name: Halt on workflow_dispatch trigger
         run: |
           echo The workflow was manually triggered, so no version bump will be pushed.
-  build:
-    uses: ./.github/workflows/build.yml
   bump-version:
     name: 'Bump version on main branch'
-    needs: [build]
+    needs: [if_manual]
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -11,12 +11,12 @@ on:
 jobs:
   if_manual:
     name: Check for workflow_dispatch
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Halt on workflow_dispatch trigger
+      - name: Halt on ${{ github.event_name }} event
         run: |
-          echo The workflow was manually triggered, so no version bump will be pushed.
+          echo Manually triggered event; halting version bump.
   bump-version:
     name: 'Bump version on main branch'
     needs: [if_manual]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          command: make site
+          command: make copied-site
           extra_flags: -f ci.conveyor.conf
           signing_key: ${{ secrets.SIGNING_KEY }}
           agree_to_license: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,10 @@ on:
         type: string
 jobs:
   build:
+    name: Build Check
     uses: ./.github/workflows/build.yml
   bump:
+    name: Bump Version
     uses: ./.github/workflows/bump.yml
   deploy:
     needs: [build, bump]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Ignore artifacts (node_modules is include by default)
 out
+output
 
 # Ignore config files
 **/.yarn
@@ -9,6 +10,6 @@ conveyor.conf
 tsconfig.json
 tsconfig.*.json
 
-# Ignore all Markdown files
+# Ignore all documentation files
 **/*.md
 LICENSE

--- a/ci.conveyor.conf
+++ b/ci.conveyor.conf
@@ -23,7 +23,7 @@ app {
   vcs-url = "github.com/EPICLab/synectic"
   site {    
     github {
-      oauth-token = ${env.GITHUB_TOKEN}
+      oauth-token = ${{ secrets.CONVEYOR }}
       // Upload the download site to a branch. 
       pages-branch = "gh-pages"
     }


### PR DESCRIPTION
Further refinements to the CI workflows.

### **Changes**:

This PR makes the following changes:
* Updates [`ci.conveyor.conf`](ci.conveyor.conf) to use `secrets.CONVEYOR` instead of `env.GITHUB_TOKEN` for corrected permissions to publish on `gh-pages` branch`
* Corrected [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) to use `conveyor make copied-site` instead of `conveyor make site` (per [Publishing through GitHub](https://conveyor.hydraulic.dev/11.4/configs/download-pages/#publishing-through-github))

