### PR TITLE
Bracket fix for ci.conveyor.conf

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,8 +10,12 @@ on:
 env:
   MANUAL_TRIGGER: ${{ github.event_name == 'workflow_dispatch' }}
 jobs:
+  build:
+    name: Build Check
+    uses: ./.github/workflows/build.yml
   bump-version:
-    name: 'Bump version on main branch'
+    name: 'Bump version on ${{ github.ref_name }} branch'
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
     name: Build Check
     uses: ./.github/workflows/build.yml
   deploy:
+    name: Deploy to GitHub Pages
     needs: [build]
     # Important: must be run from Linux.
     runs-on: ubuntu-latest

--- a/ci.conveyor.conf
+++ b/ci.conveyor.conf
@@ -23,7 +23,7 @@ app {
   vcs-url = "github.com/EPICLab/synectic"
   site {    
     github {
-      oauth-token = ${{ secrets.CONVEYOR }}
+      oauth-token = ${env.CONVEYOR}
       // Upload the download site to a branch. 
       pages-branch = "gh-pages"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synectic",
-  "version": "4.3.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synectic",
-      "version": "4.3.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synectic",
   "productName": "Synectic",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Research IDE for examining context-centric, problem-solving in development tools.",
   "main": "out/main/index.js",
   "author": {


### PR DESCRIPTION
Fix for `Deploy to GitHub Pages` action error:

```console
Parse: /home/runner/work/synectic/synectic/ci.conveyor.conf: 49: unbalanced close brace '}' with no open brace (if you intended '}' to be part of a key or string value, try enclosing the key or value in double quotes)
```

