### PR TITLE
Prevent Card overlap when fullscreen expanded by increasing `z-index` value

### DIFF
--- a/packages/renderer/src/components/Card/BaseCard.tsx
+++ b/packages/renderer/src/components/Card/BaseCard.tsx
@@ -301,7 +301,7 @@ const CardComponent = styled('div')<StyledProps>(props => ({
   transform: props.dragOverlay ? undefined : CSS.Translate.toString(props.transform),
   transition: props.dragOverlay ? undefined : props.transition,
   perspective: 1000,
-  zIndex: 1,
+  zIndex: props.expanded ? 1000 : 1,
   left: props.expanded ? 0 : props.dragOverlay || props.captured ? undefined : props.x,
   top: props.expanded ? 38.5 : props.dragOverlay || props.captured ? undefined : props.y,
   visibility: !props.dragOverlay && props.dragging ? 'hidden' : 'unset',


### PR DESCRIPTION
Prevent visual overlap when a card is expanded to fullscreen mode and other cards would normally overlay on top of that card based on `z-index` value and precedence order.

This PR resolves #1340.

## **Changes:**

This PR makes the following changes:

* Increase [`z-index`](https://github.com/EPICLab/synectic/blob/4da3b94259dcfcba201918a821bbd300e5de4c4b/packages/renderer/src/components/Card/BaseCard.tsx#L304) value to 1000 for any card expanded into fullscreen mode; and revert back to 1 when un-expanded.
